### PR TITLE
#11: Removed PHP 7 from allow_failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ matrix:
     - php: 7.0
     - php: hhvm
   allow_failures:
-    - php: 7.0
     - php: hhvm
 
 before_script:


### PR DESCRIPTION
Removed PHP 7 from the allow_failures configuration of Travis, as per issue #11 
