### PR TITLE
Enhanced exception handling for BeanExceptions in AnnotationBeanFactory

### DIFF
--- a/src/bitExpert/Disco/AnnotationBeanFactory.php
+++ b/src/bitExpert/Disco/AnnotationBeanFactory.php
@@ -66,7 +66,13 @@ class AnnotationBeanFactory implements BeanFactory
             try {
                 $instance = call_user_func([$this->beanStore, $id]);
             } catch (Exception $e) {
-                throw new BeanException($e->getMessage());
+                $message = sprintf(
+                    'Exception occured while instanciating "%s": %s',
+                    $id,
+                    $e->getMessage()
+                );
+
+                throw new BeanException($message, null, $e);
             }
         }
 


### PR DESCRIPTION
I recently ran into a problem concerning the exception handling while instanciating a bean.

If you write or use a class, which throws an exception during the constructor call, I get the following when trying to instanciate the bean by calling $beanFactory->get('myClass') for a CLI application:

```
PHP Fatal error:  Uncaught exception 'bitExpert\Disco\BeanException' with message 'Holy sh*t!' in /var/www/acme/vendor/bitexpert/disco/src/bitExpert/Disco/AnnotationBeanFactory.php:70
Stack trace:
#0 /var/www/acme/web/index.php(26): bitExpert\Disco\AnnotationBeanFactory->get('myClass')
#1 {main}
  thrown in /var/www/acme/vendor/bitexpert/disco/src/bitExpert/Disco/AnnotationBeanFactory.php on line 70

```

what hides any information about the original exception and makes it difficult to debug. 

In my case the error message was "Make sure you are passing in the correct parameters" which also could be an error of my bean configuration as well (wrong reference inside a @Parameter annotation). 

If the original exception is passed as previous for the BeanException, we will see the correct stack trace (at least when using XDebug).
