### PR TITLE
Fixes #32: BeanPostProcessor cannot depend on method with parameter.

### DIFF
--- a/src/bitExpert/Disco/Proxy/Configuration/MethodGenerator/Constructor.php
+++ b/src/bitExpert/Disco/Proxy/Configuration/MethodGenerator/Constructor.php
@@ -40,14 +40,13 @@ class Constructor extends MethodGenerator
         $parametersParameter = new ParameterGenerator('params');
         $parametersParameter->setDefaultValue([]);
 
-        $body = '// register {@link \\bitExpert\\Disco\\BeanPostProcessor} instances' . "\n";
+        $body = '$this->' . $parameterValuesProperty->getName() . ' = $' . $parametersParameter->getName() . ";\n";
+        $body .= '// register {@link \\bitExpert\\Disco\\BeanPostProcessor} instances' . "\n";
         $body .= '$this->' . $beanPostProcessorsProperty->getName() .
             '[] = new \bitExpert\Disco\BeanFactoryPostProcessor();' . "\n";
         foreach ($beanPostProcessorMethodNames as $methodName) {
             $body .= '$this->' . $beanPostProcessorsProperty->getName() . '[] = $this->' . $methodName . '(); ' . "\n";
         }
-
-        $body .= '$this->' . $parameterValuesProperty->getName() . ' = $' . $parametersParameter->getName() . ";\n";
 
         $this->setParameter($parametersParameter);
         $this->setBody($body);

--- a/tests/bitExpert/Disco/AnnotationBeanFactoryUnitTest.php
+++ b/tests/bitExpert/Disco/AnnotationBeanFactoryUnitTest.php
@@ -13,6 +13,7 @@ namespace bitExpert\Disco;
 use bitExpert\Disco\Config\BeanConfiguration;
 use bitExpert\Disco\Config\BeanConfigurationSubclass;
 use bitExpert\Disco\Config\BeanConfigurationTrait;
+use bitExpert\Disco\Config\BeanConfigurationWithParameterizedPostProcessor;
 use bitExpert\Disco\Config\BeanConfigurationWithParameters;
 use bitExpert\Disco\Config\BeanConfigurationWithPostProcessor;
 use bitExpert\Disco\Config\BeanConfigurationWithProtectedMethod;
@@ -21,6 +22,7 @@ use bitExpert\Disco\Helper\MasterService;
 use bitExpert\Disco\Helper\SampleService;
 use ProxyManager\Proxy\ValueHolderInterface;
 use ProxyManager\Proxy\VirtualProxyInterface;
+use stdClass;
 
 /**
  * Unit test for {@link \bitExpert\Disco\AnnotationBeanFactory}.
@@ -232,6 +234,23 @@ class AnnotationBeanFactoryUnitTest extends \PHPUnit_Framework_TestCase
         /** @var BeanFactoryAwareService $bean */
         $bean = $this->beanFactory->get('beanFactoryAwareBean');
         $this->assertInstanceOf(BeanFactory::class, $bean->getBeanFactory());
+    }
+
+    /**
+     * @test
+     */
+    public function beanFactoryPostProcessorIsInitializedAfterParametersAreSet()
+    {
+        $this->beanFactory = new AnnotationBeanFactory(
+            BeanConfigurationWithParameterizedPostProcessor::class,
+            ['test' => 'injectedValue']
+        );
+        BeanFactoryRegistry::register($this->beanFactory);
+
+        /** @var SampleService $bean */
+        $bean = $this->beanFactory->get('nonSingletonNonLazyRequestBean');
+        $this->assertInstanceOf(stdClass::class, $bean->test);
+        $this->assertEquals('injectedValue', $bean->test->property);
     }
 
     /**

--- a/tests/bitExpert/Disco/Config/BeanConfigurationWithParameterizedPostProcessor.php
+++ b/tests/bitExpert/Disco/Config/BeanConfigurationWithParameterizedPostProcessor.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Disco package.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace bitExpert\Disco\Config;
+
+use bitExpert\Disco\Annotations\Bean;
+use bitExpert\Disco\Annotations\BeanPostProcessor;
+use bitExpert\Disco\Annotations\Configuration;
+use bitExpert\Disco\Annotations\Parameter;
+use bitExpert\Disco\Annotations\Parameters;
+use bitExpert\Disco\Helper\ParameterizedSampleServiceBeanPostProcessor;
+use bitExpert\Disco\Helper\SampleService;
+
+/**
+ * @Configuration
+ */
+class BeanConfigurationWithParameterizedPostProcessor
+{
+    /**
+     * @BeanPostProcessor
+     * @return ParameterizedSampleServiceBeanPostProcessor
+     */
+    public function sampleServiceBeanPostProcessor()
+    {
+        return new ParameterizedSampleServiceBeanPostProcessor($this->dependency());
+    }
+
+    /**
+     * @Bean
+     * @return SampleService
+     */
+    public function nonSingletonNonLazyRequestBean()
+    {
+        return new SampleService();
+    }
+
+    /**
+     * @Bean
+     * @Parameters({
+     *  @Parameter({"name" = "test"})
+     * })
+     * @return \stdCLass
+     */
+    public function dependency($test = '')
+    {
+        $object = new \stdCLass();
+        $object->property = $test;
+        return $object;
+    }
+}

--- a/tests/bitExpert/Disco/Helper/ParameterizedSampleServiceBeanPostProcessor.php
+++ b/tests/bitExpert/Disco/Helper/ParameterizedSampleServiceBeanPostProcessor.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Disco package.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace bitExpert\Disco\Helper;
+
+use bitExpert\Disco\BeanPostProcessor;
+
+class ParameterizedSampleServiceBeanPostProcessor implements BeanPostProcessor
+{
+    protected $dependency;
+
+    /**
+     * Creates a new {@link \bitExpert\Disco\Helper\ParameterizedSampleServiceBeanPostProcessor}.
+     *
+     * @param mixed $dependency
+     */
+    public function __construct($dependency)
+    {
+        $this->dependency = $dependency;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function postProcess($bean, $beanName)
+    {
+        if ($bean instanceof SampleService) {
+            $bean->setTest($this->dependency);
+        }
+    }
+}


### PR DESCRIPTION
Made sure to initialize the parameters first before initializing the bean post processor methods. That way a bean post processor can depend on a parametrized dependency.
