### PR TITLE
Fixes #10. has() will no longer return true for protected methods

### DIFF
--- a/src/bitExpert/Disco/AnnotationBeanFactory.php
+++ b/src/bitExpert/Disco/AnnotationBeanFactory.php
@@ -88,7 +88,7 @@ class AnnotationBeanFactory implements BeanFactory
      */
     public function has($id)
     {
-        return method_exists($this->beanStore, $id);
+        return is_callable([$this->beanStore, $id]);
     }
 
     /**

--- a/tests/bitExpert/Disco/AnnotationBeanFactoryUnitTest.php
+++ b/tests/bitExpert/Disco/AnnotationBeanFactoryUnitTest.php
@@ -377,6 +377,16 @@ class AnnotationBeanFactoryUnitTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNotSame($bean1->service, $bean2->service);
     }
+    /**
+     * @test
+     */
+    public function protectedDependencyNotVisibleToTheCaller()
+    {
+        $this->beanFactory = new AnnotationBeanFactory(BeanConfigurationWithProtectedMethod::class);
+        BeanFactoryRegistry::register($this->beanFactory);
+
+        $this->assertFalse($this->beanFactory->has('singletonDependency'));
+    }
 
     /**
      * @test


### PR DESCRIPTION
Replaced the method_exists() call with is_callable() since method_exists() returns true for protected methods.
