### PR TITLE
Check bean return type against return type annotation

### DIFF
--- a/src/bitExpert/Disco/Proxy/Configuration/MethodGenerator/BeanMethod.php
+++ b/src/bitExpert/Disco/Proxy/Configuration/MethodGenerator/BeanMethod.php
@@ -109,9 +109,17 @@ class BeanMethod extends MethodGenerator
             $body .= $padding . '    $initializer   = null;' . "\n";
             $body .= $padding . '    $wrappedObject = parent::' . $methodName . '(' . $methodParamTpl . ');' . "\n";
             $body .= $padding . '    $this->initializeBean($wrappedObject, "' . $methodName . '");' . "\n";
+            $body .= $padding . '    if (!is_a($wrappedObject, \'' . $beanType . '\')) {' . "\n";
+            $body .= $padding . '        throw new \\bitExpert\\Disco\\BeanException(sprintf(' . "\n";
+            $body .= $padding . '            \'Bean "%s" has declared "%s" as return type but returned "%s"\',' . "\n";
+            $body .= $padding . '            \'' . $originalMethod->getName() . '\',' . "\n";
+            $body .= $padding . '            \'' . $beanType . '\',' . "\n";
+            $body .= $padding . '            $wrappedObject ? get_class($wrappedObject) : \'null\'' . "\n";
+            $body .= $padding . '        ));' . "\n";
+            $body .= $padding . '    }'. "\n\n";
             $body .= $padding . '    return true;' . "\n";
             $body .= $padding . '};' . "\n\n";
-            $body .= $padding . '$instance = $factory->createProxy("' . $beanType . '", $initializer);' . "\n";
+            $body .= $padding . '$instance = $factory->createProxy("' . $beanType . '", $initializer);' . "\n\n";
         } else {
             $innerpadding = $padding;
             if ($methodAnnotation->isSingleton()) {
@@ -120,7 +128,15 @@ class BeanMethod extends MethodGenerator
             }
 
             $body .= $innerpadding . '$instance = parent::' . $methodName . '(' . $methodParamTpl . ');' . "\n";
-            $body .= $innerpadding . '$this->initializeBean($instance, "' . $methodName . '");' . "\n";
+            $body .= $innerpadding . '$this->initializeBean($instance, "' . $methodName . '");' . "\n\n";
+            $body .= $innerpadding . 'if (!is_a($instance, \'' . $beanType . '\')) {' . "\n";
+            $body .= $innerpadding . '    throw new \\bitExpert\\Disco\\BeanException(sprintf(' . "\n";
+            $body .= $innerpadding . '        \'Bean "%s" has declared "%s" as return type but returned "%s"\',' . "\n";
+            $body .= $innerpadding . '        \'' . $originalMethod->getName() . '\',' . "\n";
+            $body .= $innerpadding . '        \'' . $beanType . '\',' . "\n";
+            $body .= $innerpadding . '        $instance ? get_class($instance) : \'null\'' . "\n";
+            $body .= $innerpadding . '    ));' . "\n";
+            $body .= $innerpadding . '}'. "\n\n";
 
             if ($methodAnnotation->isSingleton()) {
                 $body .= $padding . '}' . "\n";

--- a/tests/bitExpert/Disco/AnnotationBeanFactoryUnitTest.php
+++ b/tests/bitExpert/Disco/AnnotationBeanFactoryUnitTest.php
@@ -17,6 +17,7 @@ use bitExpert\Disco\Config\BeanConfigurationWithParameterizedPostProcessor;
 use bitExpert\Disco\Config\BeanConfigurationWithParameters;
 use bitExpert\Disco\Config\BeanConfigurationWithPostProcessor;
 use bitExpert\Disco\Config\BeanConfigurationWithProtectedMethod;
+use bitExpert\Disco\Config\WrongReturnTypeConfiguration;
 use bitExpert\Disco\Helper\BeanFactoryAwareService;
 use bitExpert\Disco\Helper\MasterService;
 use bitExpert\Disco\Helper\SampleService;
@@ -404,5 +405,55 @@ class AnnotationBeanFactoryUnitTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(
             count($autoloaderFunctionsBeforeBeanFactoryInit) + 1 === count($autoloaderFunctionsAfterBeanFactoryInit)
         );
+    }
+
+    /**
+     * @test
+     * @expectedException \bitExpert\Disco\BeanException
+     */
+    public function throwsExceptionIfTypeOfReturnedObjectIsNotExpectedOfNonLazyBean()
+    {
+        $this->beanFactory = new AnnotationBeanFactory(WrongReturnTypeConfiguration::class);
+        BeanFactoryRegistry::register($this->beanFactory);
+
+        $this->beanFactory->get('nonLazyBeanReturningSomethingWrong');
+    }
+
+    /**
+     * @test
+     * @expectedException \bitExpert\Disco\BeanException
+     */
+    public function throwsExceptionIfNonLazyBeanMethodDoesNotReturnAnything()
+    {
+        $this->beanFactory = new AnnotationBeanFactory(WrongReturnTypeConfiguration::class);
+        BeanFactoryRegistry::register($this->beanFactory);
+
+        $this->beanFactory->get('nonLazyBeanNotReturningAnything');
+    }
+
+    /**
+     * @test
+     * @expectedException \bitExpert\Disco\BeanException
+     */
+    public function throwsExceptionIfTypeOfReturnedObjectIsNotExpectedOfLazyBean()
+    {
+        $this->beanFactory = new AnnotationBeanFactory(WrongReturnTypeConfiguration::class);
+        BeanFactoryRegistry::register($this->beanFactory);
+
+        $bean = $this->beanFactory->get('lazyBeanReturningSomethingWrong');
+        $bean->setTest('test');
+    }
+
+    /**
+     * @test
+     * @expectedException \bitExpert\Disco\BeanException
+     */
+    public function throwsExceptionIfLazyBeanMethodDoesNotReturnAnything()
+    {
+        $this->beanFactory = new AnnotationBeanFactory(WrongReturnTypeConfiguration::class);
+        BeanFactoryRegistry::register($this->beanFactory);
+
+        $bean = $this->beanFactory->get('lazyBeanNotReturningAnything');
+        $bean->setTest('test');
     }
 }

--- a/tests/bitExpert/Disco/Config/WrongReturnTypeConfiguration.php
+++ b/tests/bitExpert/Disco/Config/WrongReturnTypeConfiguration.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Disco package.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace bitExpert\Disco\Config;
+
+use bitExpert\Disco\Annotations\Bean;
+use bitExpert\Disco\Annotations\Configuration;
+use bitExpert\Disco\Helper\MasterService;
+use bitExpert\Disco\Helper\SampleService;
+
+/**
+ * @Configuration
+ */
+class WrongReturnTypeConfiguration
+{
+    /**
+     * @Bean({"singleton"=false, "lazy"=false, "scope"="request"})
+     * @return SampleService
+     */
+    public function nonLazyBeanNotReturningAnything()
+    {
+
+    }
+
+    /**
+     * @Bean({"singleton"=false, "lazy"=false, "scope"="request"})
+     * @return SampleService
+     */
+    public function nonLazyBeanReturningSomethingWrong()
+    {
+        return new MasterService(new SampleService());
+    }
+
+    /**
+     * @Bean({"singleton"=false, "lazy"=true, "scope"="request"})
+     * @return SampleService
+     */
+    public function lazyBeanNotReturningAnything()
+    {
+
+    }
+
+    /**
+     * @Bean({"singleton"=false, "lazy"=true, "scope"="request"})
+     * @return SampleService
+     */
+    public function lazyBeanReturningSomethingWrong()
+    {
+        return new MasterService(new SampleService());
+    }
+}


### PR DESCRIPTION
Recently I ran into a problem where I used a bean as constructor argument while that argument was optional because the class would create a default object if none was given. Because the BeanFactory does neither throw an exception if the resulting object is null nor if the resulting object's type is different to the return type annotation of the bean it was really hard to figure out why my code didn't work.

So this PR includes exceptions being thrown if the cases mentioned above occur.
