### PR TITLE
Session refactoring

### DIFF
--- a/Upgrade.md
+++ b/Upgrade.md
@@ -65,20 +65,16 @@ and we do no longer need to "guess" which type might be the correct one.
 ## BC BREAK: BeanFactoryConfiguration
 
 The `\bitExpert\Disco\BeanFactoryConfiguration::__construct()` method 
-changed. The 4th parameter is no longer a bool but an instance of 
-`\ProxyManager\Autoloader\AutoloaderInterface`
+signature changed. The constructor accepts just one parameter which 
+defines the directory where the proxy classes and the annotation metadata
+are stored. To configure a proxy autoloader instance or a proxy genrator
+instance use the respective setter methods of the object.
 
-To make your life easier make use of the factory method 
-`\bitExpert\Disco\BeanFactoryConfiguration::getDefault()` to quickly
-set up a configuration instance.
+## BC BREAK: Serialization of AnnotationBeanFactory
 
-## BC BREAK: EvalStrategy (ProxyManager)
-
-When not using the BeanFactoryConfiguration to configure the BeanFactory
-internals, ProxyManager in version 2.x will make use of the 
-`\ProxyManager\GeneratorStrategy\EvaluatingGeneratorStrategy` instead of 
-`\ProxyManager\GeneratorStrategy\FileWriterGeneratorStrategy`. Depending 
-on the complexitity of your configuration class and depending on how many
-traits you might use this can lead to a poor performance.
-
-Follow the advice in the README.md file on performance tuning.
+To make use of the session-aware beans it is no longer possible to serialize
+the `\bitExpert\Disco\AnnotationBeanFactory` instance. Instead grab the 
+`\bitExpert\Disco\Store\BeanStore` instance by calling 
+`\bitExpert\Disco\BeanFactoryConfiguration::getSessionBeanStore()` and serialize
+it. Pass the unserialized object to the `\bitExpert\Disco\BeanFactoryConfiguration`
+before creating the `\bitExpert\Disco\AnnotationBeanFactory` instance.

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,7 @@
     "phpdocumentor/phpdocumentor": "v2.9.0",
     "monolog/monolog": "^1.21.0",
     "phing/phing": "^2.14.0",
-    "bitexpert/phing-securitychecker": "^0.2.1",
-    "mikey179/vfsStream": "^1.6"
+    "bitexpert/phing-securitychecker": "^0.2.1"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "b804f712412afdca74d1a00ab7494f69",
-    "content-hash": "f1bcba1ac122f7256ddd7972f2984b57",
+    "hash": "02be3183fa47339546baf8f139b1893b",
+    "content-hash": "3017a401ff02857cd1328b3dcca78255",
     "packages": [
         {
             "name": "bitexpert/slf4psrlog",
@@ -996,16 +996,16 @@
         },
         {
             "name": "jms/serializer",
-            "version": "1.2.0",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/serializer.git",
-                "reference": "ef0bfc44272a6439da7355f67904b9678c603e0a"
+                "reference": "705d0b4633b9c44e6253aa18306b3972282cd3a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/serializer/zipball/ef0bfc44272a6439da7355f67904b9678c603e0a",
-                "reference": "ef0bfc44272a6439da7355f67904b9678c603e0a",
+                "url": "https://api.github.com/repos/schmittjoh/serializer/zipball/705d0b4633b9c44e6253aa18306b3972282cd3a3",
+                "reference": "705d0b4633b9c44e6253aa18306b3972282cd3a3",
                 "shasum": ""
             },
             "require": {
@@ -1022,7 +1022,7 @@
             },
             "require-dev": {
                 "doctrine/orm": "~2.1",
-                "doctrine/phpcr-odm": "^1.3",
+                "doctrine/phpcr-odm": "^1.3|^2.0",
                 "jackalope/jackalope-doctrine-dbal": "^1.1.5",
                 "phpunit/phpunit": "^4.8|^5.0",
                 "propel/propel1": "~1.7",
@@ -1039,7 +1039,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
@@ -1066,7 +1066,7 @@
                 "serialization",
                 "xml"
             ],
-            "time": "2016-08-03 12:52:48"
+            "time": "2016-08-23 17:20:24"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -1175,52 +1175,6 @@
             "description": "A parsing and comparison library for semantic versioning.",
             "homepage": "http://github.com/kherge/Version",
             "time": "2012-08-16 17:13:03"
-        },
-        {
-            "name": "mikey179/vfsStream",
-            "version": "v1.6.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/mikey179/vfsStream.git",
-                "reference": "0247f57b2245e8ad2e689d7cee754b45fbabd592"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/mikey179/vfsStream/zipball/0247f57b2245e8ad2e689d7cee754b45fbabd592",
-                "reference": "0247f57b2245e8ad2e689d7cee754b45fbabd592",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.6.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "org\\bovigo\\vfs\\": "src/main/php"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Frank Kleine",
-                    "homepage": "http://frankkleine.de/",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Virtual file system to mock the real file system in unit tests.",
-            "homepage": "http://vfs.bovigo.org/",
-            "time": "2016-07-18 14:02:57"
         },
         {
             "name": "monolog/monolog",
@@ -2160,16 +2114,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.5.2",
+            "version": "5.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "46ec2d1522ae8c9a12aca6b7650e0be78bbb0502"
+                "reference": "3e6e88e56c912133de6e99b87728cca7ed70c5f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/46ec2d1522ae8c9a12aca6b7650e0be78bbb0502",
-                "reference": "46ec2d1522ae8c9a12aca6b7650e0be78bbb0502",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3e6e88e56c912133de6e99b87728cca7ed70c5f5",
+                "reference": "3e6e88e56c912133de6e99b87728cca7ed70c5f5",
                 "shasum": ""
             },
             "require": {
@@ -2234,20 +2188,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-08-18 11:10:44"
+            "time": "2016-08-26 07:11:44"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "3.2.4",
+            "version": "3.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "4e83390f64e7ce04fcaec2ce95cd72823b431d19"
+                "reference": "46b249b43fd2ed8e127aa0fdb3cbcf56e9bc0e49"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/4e83390f64e7ce04fcaec2ce95cd72823b431d19",
-                "reference": "4e83390f64e7ce04fcaec2ce95cd72823b431d19",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/46b249b43fd2ed8e127aa0fdb3cbcf56e9bc0e49",
+                "reference": "46b249b43fd2ed8e127aa0fdb3cbcf56e9bc0e49",
                 "shasum": ""
             },
             "require": {
@@ -2293,7 +2247,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2016-08-17 09:33:51"
+            "time": "2016-08-26 05:51:59"
         },
         {
             "name": "pimple/pimple",

--- a/src/bitExpert/Disco/BeanFactoryConfiguration.php
+++ b/src/bitExpert/Disco/BeanFactoryConfiguration.php
@@ -8,7 +8,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace bitExpert\Disco;
 
@@ -17,13 +17,11 @@ use bitExpert\Disco\Store\SerializableBeanStore;
 use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Cache\FilesystemCache;
 use InvalidArgumentException;
-use ProxyManager\Autoloader\Autoloader;
 use ProxyManager\Autoloader\AutoloaderInterface;
 use ProxyManager\Configuration;
 use ProxyManager\FileLocator\FileLocator;
 use ProxyManager\GeneratorStrategy\FileWriterGeneratorStrategy;
 use ProxyManager\GeneratorStrategy\GeneratorStrategyInterface;
-use ProxyManager\Inflector\ClassNameInflector;
 use RuntimeException;
 
 /**
@@ -59,17 +57,26 @@ class BeanFactoryConfiguration
      *
      * @param string $proxyTargetDir
      * @throws InvalidArgumentException
-     * @throws RuntimeException
      */
-    public function __construct($proxyTargetDir) {
-        $proxyFileLocator = new FileLocator($proxyTargetDir);
-        $classNameInflector = new ClassNameInflector(Configuration::DEFAULT_PROXY_NAMESPACE);
+    public function __construct($proxyTargetDir)
+    {
+        try {
+            $proxyFileLocator = new FileLocator($proxyTargetDir);
+        } catch (\Exception $e) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Proxy target directory "%s" does not exist!',
+                    $proxyTargetDir
+                ),
+                $e->getCode(),
+                $e
+            );
+        }
 
         $this->setProxyTargetDir($proxyTargetDir);
         $this->setAnnotationCache(new FilesystemCache($proxyTargetDir));
         $this->setBeanStore(new SerializableBeanStore());
         $this->setProxyWriterGenerator(new FileWriterGeneratorStrategy($proxyFileLocator));
-        $this->setProxyAutoloader(new Autoloader($proxyFileLocator, $classNameInflector));
     }
 
     /**
@@ -144,16 +151,16 @@ class BeanFactoryConfiguration
     public function setProxyAutoloader(AutoloaderInterface $autoloader)
     {
         if ($this->proxyAutoloader instanceof AutoloaderInterface) {
-            if(!spl_autoload_unregister($this->proxyAutoloader)) {
+            if (!spl_autoload_unregister($this->proxyAutoloader)) {
                 throw new RuntimeException(
-                  sprintf('Cannot unregister autoloader "%s"', get_class($this->proxyAutoloader))
+                    sprintf('Cannot unregister autoloader "%s"', get_class($this->proxyAutoloader))
                 );
             }
         }
 
         $this->proxyAutoloader = $autoloader;
 
-        if(!spl_autoload_register($this->proxyAutoloader, false)) {
+        if (!spl_autoload_register($this->proxyAutoloader, false)) {
             throw new RuntimeException(
                 sprintf('Cannot register autoloader "%s"', get_class($this->proxyAutoloader))
             );

--- a/src/bitExpert/Disco/BeanFactoryConfiguration.php
+++ b/src/bitExpert/Disco/BeanFactoryConfiguration.php
@@ -46,7 +46,7 @@ class BeanFactoryConfiguration
     /**
      * @var GeneratorStrategyInterface
      */
-    protected $proxyGeneratorStrategy;
+    protected $proxyWriterGenerator;
     /**
      * @var AutoloaderInterface
      */

--- a/src/bitExpert/Disco/BeanFactoryConfiguration.php
+++ b/src/bitExpert/Disco/BeanFactoryConfiguration.php
@@ -38,7 +38,7 @@ class BeanFactoryConfiguration
     /**
      * @var BeanStore
      */
-    protected $beanStore;
+    protected $sessionBeanStore;
     /**
      * @var string
      */
@@ -75,7 +75,7 @@ class BeanFactoryConfiguration
 
         $this->setProxyTargetDir($proxyTargetDir);
         $this->setAnnotationCache(new FilesystemCache($proxyTargetDir));
-        $this->setBeanStore(new SerializableBeanStore());
+        $this->setSessionBeanStore(new SerializableBeanStore());
         $this->setProxyWriterGenerator(new FileWriterGeneratorStrategy($proxyFileLocator));
     }
 
@@ -94,11 +94,11 @@ class BeanFactoryConfiguration
      * Sets the {@link \bitExpert\Disco\Store\BeanStore} instance used to store the
      * session-aware beans.
      *
-     * @param BeanStore $beanStore
+     * @param BeanStore $sessionBeanStore
      */
-    public function setBeanStore(BeanStore $beanStore)
+    public function setSessionBeanStore(BeanStore $sessionBeanStore)
     {
-        $this->beanStore = $beanStore;
+        $this->sessionBeanStore = $sessionBeanStore;
     }
 
     /**
@@ -206,8 +206,8 @@ class BeanFactoryConfiguration
      *
      * @return BeanStore
      */
-    public function getBeanStore() : BeanStore
+    public function getSessionBeanStore() : BeanStore
     {
-        return $this->beanStore;
+        return $this->sessionBeanStore;
     }
 }

--- a/src/bitExpert/Disco/Proxy/Configuration/ConfigurationFactory.php
+++ b/src/bitExpert/Disco/Proxy/Configuration/ConfigurationFactory.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace bitExpert\Disco\Proxy\Configuration;
 
 use bitExpert\Disco\BeanFactoryConfiguration;
+use bitExpert\Disco\Store\BeanStore;
 use Doctrine\Common\Cache\VoidCache;
 use ProxyManager\Configuration;
 use ProxyManager\Factory\AbstractBaseFactory;
@@ -33,41 +34,25 @@ class ConfigurationFactory extends AbstractBaseFactory
      *
      * @param BeanFactoryConfiguration $config
      */
-    public function __construct(BeanFactoryConfiguration $config = null)
+    public function __construct(BeanFactoryConfiguration $config)
     {
-        $proxyManagerConfiguration = null;
-        $annotationCache = new VoidCache();
-        if ($config !== null) {
-            $proxyManagerConfiguration = new Configuration();
-            $proxyManagerConfiguration->setProxiesTargetDir($config->getProxyTargetDir());
+        parent::__construct($config->getProxyManagerConfiguration());
 
-            if ($config->getProxyGeneratorStrategy() !== null) {
-                $proxyManagerConfiguration->setGeneratorStrategy($config->getProxyGeneratorStrategy());
-            }
-
-            if ($config->getProxyAutoloader()) {
-                $proxyManagerConfiguration->setProxyAutoloader($config->getProxyAutoloader());
-            }
-
-            $annotationCache = $config->getAnnotationCache();
-        }
-        parent::__construct($proxyManagerConfiguration);
-
-        $this->generator = new ConfigurationGenerator($annotationCache);
+        $this->generator = new ConfigurationGenerator($config->getAnnotationCache());
     }
 
     /**
      * Creates an instance of the given $configClassName.
      *
+     * @param BeanFactoryConfiguration $config
      * @param string $configClassName name of the configuration class
      * @param array $parameters
      * @return object
      */
-    public function createInstance($configClassName, array $parameters = [])
+    public function createInstance(BeanFactoryConfiguration $config, $configClassName, array $parameters = [])
     {
         $proxyClassName = $this->generateProxy($configClassName);
-
-        return new $proxyClassName($parameters);
+        return new $proxyClassName($config, $parameters);
     }
 
     /**

--- a/src/bitExpert/Disco/Proxy/Configuration/ConfigurationGenerator.php
+++ b/src/bitExpert/Disco/Proxy/Configuration/ConfigurationGenerator.php
@@ -23,6 +23,7 @@ use bitExpert\Disco\Proxy\Configuration\MethodGenerator\GetParameter;
 use bitExpert\Disco\Proxy\Configuration\MethodGenerator\HasAlias;
 use bitExpert\Disco\Proxy\Configuration\MethodGenerator\MagicSleep;
 use bitExpert\Disco\Proxy\Configuration\PropertyGenerator\AliasesProperty;
+use bitExpert\Disco\Proxy\Configuration\PropertyGenerator\BeanFactoryConfigurationProperty;
 use bitExpert\Disco\Proxy\Configuration\PropertyGenerator\BeanPostProcessorsProperty;
 use bitExpert\Disco\Proxy\Configuration\PropertyGenerator\ForceLazyInitProperty;
 use bitExpert\Disco\Proxy\Configuration\PropertyGenerator\ParameterValuesProperty;
@@ -87,13 +88,14 @@ class ConfigurationGenerator implements ProxyGeneratorInterface
         $sessionBeansProperty = new SessionBeansProperty();
         $postProcessorsProperty = new BeanPostProcessorsProperty();
         $parameterValuesProperty = new ParameterValuesProperty();
+        $beanFactoryConfigurationProperty = new BeanFactoryConfigurationProperty();
         $aliasesProperty = new AliasesProperty();
         $getParameterMethod = new GetParameter($originalClass, $parameterValuesProperty);
 
         try {
             $annotation = $this->reader->getClassAnnotation($originalClass, Configuration::class);
         } catch (Exception $e) {
-            throw new InvalidProxiedClassException($e->getMessage(), 0, $e);
+            throw new InvalidProxiedClassException($e->getMessage(), $e->getCode(), $e);
         }
 
         if (null === $annotation) {
@@ -111,6 +113,7 @@ class ConfigurationGenerator implements ProxyGeneratorInterface
         $classGenerator->addPropertyFromGenerator($sessionBeansProperty);
         $classGenerator->addPropertyFromGenerator($postProcessorsProperty);
         $classGenerator->addPropertyFromGenerator($parameterValuesProperty);
+        $classGenerator->addPropertyFromGenerator($beanFactoryConfigurationProperty);
         $classGenerator->addPropertyFromGenerator($aliasesProperty);
 
         $postProcessorMethods = [];
@@ -182,6 +185,7 @@ class ConfigurationGenerator implements ProxyGeneratorInterface
                 $forceLazyInitProperty,
                 $sessionBeansProperty,
                 $postProcessorsProperty,
+                $beanFactoryConfigurationProperty,
                 $beanType
             );
             $classGenerator->addMethodFromGenerator($proxyMethod);
@@ -192,9 +196,11 @@ class ConfigurationGenerator implements ProxyGeneratorInterface
         $classGenerator->addMethodFromGenerator(
             new Constructor(
                 $originalClass,
+                $parameterValuesProperty,
+                $sessionBeansProperty,
+                $beanFactoryConfigurationProperty,
                 $postProcessorsProperty,
-                $postProcessorMethods,
-                $parameterValuesProperty
+                $postProcessorMethods
             )
         );
         $classGenerator->addMethodFromGenerator($getParameterMethod);

--- a/src/bitExpert/Disco/Proxy/Configuration/MethodGenerator/Constructor.php
+++ b/src/bitExpert/Disco/Proxy/Configuration/MethodGenerator/Constructor.php
@@ -56,7 +56,7 @@ class Constructor extends MethodGenerator
         $body .= '$this->' . $beanFactoryConfigurationProperty->getName() .
             ' = $' . $beanFactoryConfigurationParameter->getName() . ';';
         $body .= '$this->' . $sessionBeansProperty->getName() . ' = $' . $beanFactoryConfigurationParameter->getName() .
-            '->getBeanStore();' . PHP_EOL;
+            '->getSessionBeanStore();' . PHP_EOL;
         $body .= '// register {@link \\bitExpert\\Disco\\BeanPostProcessor} instances' . PHP_EOL;
         $body .= '$this->' . $beanPostProcessorsProperty->getName() .
             '[] = new \bitExpert\Disco\BeanFactoryPostProcessor();' . PHP_EOL;

--- a/src/bitExpert/Disco/Proxy/Configuration/PropertyGenerator/BeanFactoryConfigurationProperty.php
+++ b/src/bitExpert/Disco/Proxy/Configuration/PropertyGenerator/BeanFactoryConfigurationProperty.php
@@ -12,25 +12,26 @@ declare(strict_types=1);
 
 namespace bitExpert\Disco\Proxy\Configuration\PropertyGenerator;
 
+use bitExpert\Disco\BeanFactoryConfiguration;
 use ProxyManager\Generator\Util\UniqueIdentifierGenerator;
 use Zend\Code\Generator\Exception\InvalidArgumentException;
 use Zend\Code\Generator\PropertyGenerator;
 
 /**
- * Private property to store the session beans (which which gets persisted after the request).
+ * Private property to store the {@link \bitExpert\Disco\BeanFactoryConfiguration}.
  */
-class SessionBeansProperty extends PropertyGenerator
+class BeanFactoryConfigurationProperty extends PropertyGenerator
 {
     /**
-     * Creates a new {@link \bitExpert\Disco\Proxy\Configuration\PropertyGenerator\SessionBeansProperty}.
+     * Creates a new {@link \bitExpert\Disco\Proxy\Configuration\PropertyGenerator\BeanFactoryConfigurationProperty}.
      *
      * @throws InvalidArgumentException
      */
     public function __construct()
     {
-        parent::__construct(UniqueIdentifierGenerator::getIdentifier('sessionBeans'));
+        parent::__construct(UniqueIdentifierGenerator::getIdentifier('config'));
 
         $this->setVisibility(self::VISIBILITY_PRIVATE);
-        $this->setDocBlock('@var '.\bitExpert\Disco\Store\BeanStore::class);
+        $this->setDocBlock('@var '.BeanFactoryConfiguration::class);
     }
 }

--- a/src/bitExpert/Disco/Proxy/Configuration/PropertyGenerator/BeanPostProcessorsProperty.php
+++ b/src/bitExpert/Disco/Proxy/Configuration/PropertyGenerator/BeanPostProcessorsProperty.php
@@ -32,6 +32,6 @@ class BeanPostProcessorsProperty extends PropertyGenerator
 
         $this->setDefaultValue([]);
         $this->setVisibility(self::VISIBILITY_PRIVATE);
-        $this->setDocBlock('@var \bitExpert\Disco\BeanPostProcessor[]');
+        $this->setDocBlock('@var '.\bitExpert\Disco\BeanFactoryPostProcessor::class.'[]');
     }
 }

--- a/src/bitExpert/Disco/Store/BeanStore.php
+++ b/src/bitExpert/Disco/Store/BeanStore.php
@@ -32,4 +32,13 @@ interface BeanStore
      * @throws InvalidArgumentException
      */
     public function get(string $beanId);
+
+    /**
+     * Checks if a bean instance for $beanId exists. Will return true if an instance
+     * exists and false if no instance can be found.
+     *
+     * @param string $beanId
+     * @return bool
+     */
+    public function has(string $beanId) : bool;
 }

--- a/src/bitExpert/Disco/Store/BeanStore.php
+++ b/src/bitExpert/Disco/Store/BeanStore.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Disco package.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+declare(strict_types = 1);
+
+namespace bitExpert\Disco\Store;
+
+use InvalidArgumentException;
+
+interface BeanStore
+{
+    /**
+     * Adds given $bean instance (or primitive) to the bean store by the given $beanId.
+     *
+     * @param string $beanId
+     * @param mixed $bean
+     */
+    public function add(string $beanId, $bean);
+
+    /**
+     * Retrieves bean instance for $beanId.
+     *
+     * @param string $beanId
+     * @return mixed
+     * @throws InvalidArgumentException
+     */
+    public function get(string $beanId);
+}

--- a/src/bitExpert/Disco/Store/SerializableBeanStore.php
+++ b/src/bitExpert/Disco/Store/SerializableBeanStore.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Disco package.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+declare(strict_types = 1);
+
+namespace bitExpert\Disco\Store;
+
+/**
+ * The {@link \bitExpert\Disco\Store\SerializableBeanStore} contains all session-aware beans which
+ * can be persisted in your preferable format.
+ */
+class SerializableBeanStore implements BeanStore
+{
+    /**
+     * @var array
+     */
+    protected $beans;
+
+    /**
+     * Creates a new {@link \bitExpert\Disco\Store\SerializableBeanStore}.
+     */
+    public function __construct()
+    {
+        $this->beans = [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function add(string $beanId, $bean)
+    {
+        $this->beans[$beanId] = $bean;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get(string $beanId)
+    {
+        if (!isset($this->beans[$beanId])) {
+            throw new \InvalidArgumentException(
+              sprintf('Bean "%s" not defined in store!', $beanId)
+            );
+        }
+
+        return $this->beans[$beanId];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __sleep()
+    {
+        return ['beans'];
+    }
+}

--- a/src/bitExpert/Disco/Store/SerializableBeanStore.php
+++ b/src/bitExpert/Disco/Store/SerializableBeanStore.php
@@ -46,11 +46,19 @@ class SerializableBeanStore implements BeanStore
     {
         if (!isset($this->beans[$beanId])) {
             throw new \InvalidArgumentException(
-              sprintf('Bean "%s" not defined in store!', $beanId)
+                sprintf('Bean "%s" not defined in store!', $beanId)
             );
         }
 
         return $this->beans[$beanId];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has(string $beanId) : bool
+    {
+        return isset($this->beans[$beanId]);
     }
 
     /**

--- a/tests/bitExpert/Disco/AnnotationBeanFactoryUnitTest.php
+++ b/tests/bitExpert/Disco/AnnotationBeanFactoryUnitTest.php
@@ -178,33 +178,6 @@ class AnnotationBeanFactoryUnitTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function beanFactoryCanBePersistedOnDisk()
-    {
-        $rootDir = vfsStream::setup('disco');
-        $locator = $this->createMock(FileLocatorInterface::class);
-        $locator->method('getProxyFileName')
-            ->willReturn($rootDir->url() . DIRECTORY_SEPARATOR . 'cache.php');
-        $loader = new Autoloader($locator, new ClassNameInflector(Configuration::DEFAULT_PROXY_NAMESPACE));
-        $strategy = new FileWriterGeneratorStrategy($locator);
-
-        $config = new BeanFactoryConfiguration($rootDir->url(), $strategy, null, $loader);
-        $this->beanFactory = new AnnotationBeanFactory(BeanConfigurationPersistence::class, [], $config);
-        BeanFactoryRegistry::register($this->beanFactory);
-
-        $beanBefore = $this->beanFactory->get('sampleService');
-
-        $serialized = serialize($this->beanFactory);
-        $this->beanFactory = unserialize($serialized);
-
-        $beanAfter = $this->beanFactory->get('sampleService');
-
-        self::assertSame($beanBefore, $beanAfter);
-        self::assertTrue($rootDir->hasChild('cache.php'));
-    }
-
-    /**
-     * @test
-     */
     public function initializedBeanHookGetsCalledOnlyWhenBeanGetsCreated()
     {
         $bean = $this->beanFactory->get('singletonInitializedService');

--- a/tests/bitExpert/Disco/BeanFactoryConfigurationUnitTest.php
+++ b/tests/bitExpert/Disco/BeanFactoryConfigurationUnitTest.php
@@ -141,8 +141,8 @@ class BeanFactoryConfigurationUnitTest extends \PHPUnit_Framework_TestCase
         $beanStore = new SerializableBeanStore();
 
         $config = new BeanFactoryConfiguration(sys_get_temp_dir());
-        $config->setBeanStore($beanStore);
+        $config->setSessionBeanStore($beanStore);
 
-        self::assertSame($beanStore, $config->getBeanStore());
+        self::assertSame($beanStore, $config->getSessionBeanStore());
     }
 }

--- a/tests/bitExpert/Disco/Store/SerializableBeanStoreUnitTest.php
+++ b/tests/bitExpert/Disco/Store/SerializableBeanStoreUnitTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the Disco package.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace bitExpert\Disco\Store;
+
+use bitExpert\Disco\Helper\MasterService;
+use bitExpert\Disco\Helper\SampleService;
+use Doctrine\Instantiator\Exception\InvalidArgumentException;
+
+/**
+ * Unit test for {@link \bitExpert\Disco\Store\SerializableBeanStoreUnitTest}.
+ */
+class SerializableBeanStoreUnitTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var SerializableBeanStore
+     */
+    private $beanStore;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->beanStore = new SerializableBeanStore();
+    }
+
+    /**
+     * @test
+     * @dataProvider beanProvider
+     */
+    public function addingAndRetrievingBeansSucceeds($bean)
+    {
+        $this->beanStore->add('bean', $bean);
+        $beanFromStore = $this->beanStore->get('bean');
+
+        self::assertSame($bean, $beanFromStore);
+    }
+
+    /**
+     * @test
+     */
+    public function addingBeanWithSameBeanIdMultipleTimeWillNotTriggerError()
+    {
+        $service = new SampleService();
+        $bean = new MasterService($service);
+
+        $this->beanStore->add('bean', $service);
+        $this->beanStore->add('bean', $bean);
+        $beanFromStore = $this->beanStore->get('bean');
+
+        self::assertSame($bean, $beanFromStore);
+    }
+
+    /**
+     * @test
+     * @expectedException InvalidArgumentException
+     */
+    public function gettingNonExistentBeanWillThrowException()
+    {
+        $this->beanStore->get('some-random-bean-instance');
+    }
+
+    /**
+     * @test
+     * @dataProvider beanProvider
+     */
+    public function beanStoreCanBeSerialized($bean)
+    {
+        $this->beanStore->add('bean', $bean);
+
+        $this->beanStore = serialize($this->beanStore);
+        $this->beanStore = unserialize($this->beanStore);
+
+        $beanFromStore = $this->beanStore->get('bean');
+        self::assertEquals($bean, $beanFromStore);
+    }
+
+    public function beanProvider()
+    {
+        return [
+            [new SampleService()],
+            [1],
+            [1.23],
+            [false],
+            ['some string']
+        ];
+    }
+}


### PR DESCRIPTION
This PR fixes 2 issues:
- Session-aware beans can be properly serialized and unserialized again. A separate bean store object was introduced for that reason.
- The lazy factories are aware of the global BeanConfiguration instance and thus follow the same rules (e.g. ProxyWriter, ProxyAutoloader) as the bean configuration class.
