### PR TITLE
Remove Doctrine Cache dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,12 +285,6 @@ Since a lot of parsing and reflection logic is involved during the conversion pr
 into its "final format" Disco can be rather slow in production mode and during development, especially when 
 running  Disco in a virtual machine with a shared hosts folder.
 
-### doctrine/annotations
-
-Make sure to follow the hints on how to improve performance for [Doctrine Annotations](http://doctrine-orm.readthedocs.org/projects/doctrine-common/en/latest/reference/annotations.html) and pick a 
-`\Doctrine\Common\Cache\Cache` implementation that suites your needs. To use a specific cache 
-implementation pass an instance of it to `\bitExpert\Disco\BeanFactoryConfiguration::construct()` as the third parameter.
-
 ### ocramius/ProxyManager
 
 [ProxyManager](https://github.com/Ocramius/ProxyManager) also needs to be configured for faster performance. Read about the details [here](https://ocramius.github.io/ProxyManager/docs/tuning-for-production.html).

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
     "php": "7.0.0 - 7.0.5 || ^7.0.7",
     "container-interop/container-interop": "^1.1.0",
     "doctrine/annotations": "v1.2.7",
-    "doctrine/cache": "^1.6.0",
     "ocramius/proxy-manager": "^2.0.3",
     "bitexpert/slf4psrlog": "^0.1.3"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "02be3183fa47339546baf8f139b1893b",
-    "content-hash": "3017a401ff02857cd1328b3dcca78255",
+    "hash": "dfd225248d5ed461979a1bd8b3060e93",
+    "content-hash": "251802b83dda289560c09d07a7b46f15",
     "packages": [
         {
             "name": "bitexpert/slf4psrlog",
@@ -147,76 +147,6 @@
                 "parser"
             ],
             "time": "2015-08-31 12:32:49"
-        },
-        {
-            "name": "doctrine/cache",
-            "version": "v1.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/cache.git",
-                "reference": "f8af318d14bdb0eff0336795b428b547bd39ccb6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/cache/zipball/f8af318d14bdb0eff0336795b428b547bd39ccb6",
-                "reference": "f8af318d14bdb0eff0336795b428b547bd39ccb6",
-                "shasum": ""
-            },
-            "require": {
-                "php": "~5.5|~7.0"
-            },
-            "conflict": {
-                "doctrine/common": ">2.2,<2.4"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.8|~5.0",
-                "predis/predis": "~1.0",
-                "satooshi/php-coveralls": "~0.6"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.6.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
-                    "name": "Benjamin Eberlei",
-                    "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
-                },
-                {
-                    "name": "Jonathan Wage",
-                    "email": "jonwage@gmail.com"
-                },
-                {
-                    "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com"
-                }
-            ],
-            "description": "Caching library offering an object-oriented API for many cache backends",
-            "homepage": "http://www.doctrine-project.org",
-            "keywords": [
-                "cache",
-                "caching"
-            ],
-            "time": "2015-12-31 16:37:02"
         },
         {
             "name": "doctrine/lexer",

--- a/src/bitExpert/Disco/BeanFactoryConfiguration.php
+++ b/src/bitExpert/Disco/BeanFactoryConfiguration.php
@@ -14,8 +14,6 @@ namespace bitExpert\Disco;
 
 use bitExpert\Disco\Store\BeanStore;
 use bitExpert\Disco\Store\SerializableBeanStore;
-use Doctrine\Common\Cache\Cache;
-use Doctrine\Common\Cache\FilesystemCache;
 use InvalidArgumentException;
 use ProxyManager\Autoloader\AutoloaderInterface;
 use ProxyManager\Configuration;
@@ -31,10 +29,6 @@ use RuntimeException;
  */
 class BeanFactoryConfiguration
 {
-    /**
-     * @var Cache
-     */
-    protected $annotationCache;
     /**
      * @var BeanStore
      */
@@ -74,21 +68,10 @@ class BeanFactoryConfiguration
         }
 
         $this->setProxyTargetDir($proxyTargetDir);
-        $this->setAnnotationCache(new FilesystemCache($proxyTargetDir));
         $this->setSessionBeanStore(new SerializableBeanStore());
         $this->setProxyWriterGenerator(new FileWriterGeneratorStrategy($proxyFileLocator));
     }
 
-    /**
-     * Sets the {@link \Doctrine\Common\Cache\Cache} to store the parsed annotation
-     * metadata in.
-     *
-     * @param Cache $annotationCache
-     */
-    public function setAnnotationCache(Cache $annotationCache)
-    {
-        $this->annotationCache = $annotationCache;
-    }
 
     /**
      * Sets the {@link \bitExpert\Disco\Store\BeanStore} instance used to store the
@@ -187,17 +170,6 @@ class BeanFactoryConfiguration
         }
 
         return $proxyManagerConfiguration;
-    }
-
-    /**
-     * Returns the configured {@link \Doctrine\Common\Cache\Cache} used to store
-     * the parsed annotation metadata in.
-     *
-     * @return Cache
-     */
-    public function getAnnotationCache() : Cache
-    {
-        return $this->annotationCache;
     }
 
     /**

--- a/src/bitExpert/Disco/Proxy/Configuration/ConfigurationFactory.php
+++ b/src/bitExpert/Disco/Proxy/Configuration/ConfigurationFactory.php
@@ -38,7 +38,7 @@ class ConfigurationFactory extends AbstractBaseFactory
     {
         parent::__construct($config->getProxyManagerConfiguration());
 
-        $this->generator = new ConfigurationGenerator($config->getAnnotationCache());
+        $this->generator = new ConfigurationGenerator();
     }
 
     /**

--- a/tests/bitExpert/Disco/BeanFactoryConfigurationUnitTest.php
+++ b/tests/bitExpert/Disco/BeanFactoryConfigurationUnitTest.php
@@ -49,48 +49,6 @@ class BeanFactoryConfigurationUnitTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function defaultAnnotationCacheDirWillDefaultToProxyTargetDir()
-    {
-        $config = new BeanFactoryConfiguration(sys_get_temp_dir());
-
-        /** @var FilesystemCache $annotationCache */
-        $annotationCache = $config->getAnnotationCache();
-
-        self::assertInstanceOf(FilesystemCache::class, $annotationCache);
-        self::assertSame(sys_get_temp_dir(), $annotationCache->getDirectory());
-    }
-
-    /**
-     * @test
-     */
-    public function customAnnotationCacheDirCanBeConfigured()
-    {
-        $config = new BeanFactoryConfiguration(sys_get_temp_dir());
-        $config->setAnnotationCache(new FilesystemCache(__DIR__));
-
-        /** @var FilesystemCache $annotationCache */
-        $annotationCache = $config->getAnnotationCache();
-
-        self::assertInstanceOf(FilesystemCache::class, $annotationCache);
-        self::assertSame(__DIR__, $annotationCache->getDirectory());
-    }
-
-    /**
-     * @test
-     */
-    public function configuredAnnotationCacheInstanceCanBeRetrieved()
-    {
-        $config = new BeanFactoryConfiguration(sys_get_temp_dir());
-        $config->setAnnotationCache(new VoidCache());
-
-        $annotationCache = $config->getAnnotationCache();
-
-        self::assertInstanceOf(VoidCache::class, $annotationCache);
-    }
-
-    /**
-     * @test
-     */
     public function configuredGeneratorStrategyInstanceCanBeRetrieved()
     {
         $config = new BeanFactoryConfiguration(sys_get_temp_dir());


### PR DESCRIPTION
So far Doctrine Cache was used to be able to cache the Doctrine annotation meta data. Due to some [issues](https://github.com/doctrine/annotations/pull/62) with the annotation CachedReader, the caching functionality was removed as it only was relevant for development mode.
