### PR TITLE
Allow parameters in BeanPostProcessor configuration

### DIFF
--- a/src/bitExpert/Disco/Annotations/Bean.php
+++ b/src/bitExpert/Disco/Annotations/Bean.php
@@ -27,7 +27,7 @@ use Doctrine\Common\Annotations\AnnotationException;
  *   @Attribute("parameters", type = "array<\bitExpert\Disco\Annotations\Parameter>")
  * })
  */
-final class Bean
+final class Bean extends ParameterAwareAnnotation
 {
     const SCOPE_REQUEST = 1;
     const SCOPE_SESSION = 2;
@@ -47,10 +47,6 @@ final class Bean
      * @var Alias[]
      */
     protected $aliases;
-    /**
-     * @var Parameter[]
-     */
-    protected $parameters;
 
     /**
      * Creates a new {@link \bitExpert\Disco\Annotations\Bean}.
@@ -60,12 +56,12 @@ final class Bean
      */
     public function __construct(array $attributes = [])
     {
+        parent::__construct();
         // initialize default values
         $this->scope = self::SCOPE_REQUEST;
         $this->singleton = true;
         $this->lazy = false;
         $this->aliases = [];
-        $this->parameters = [];
 
         if (isset($attributes['value'])) {
             if (isset($attributes['value']['scope']) && (strtolower($attributes['value']['scope']) === 'session')) {
@@ -80,12 +76,12 @@ final class Bean
                 $this->lazy = AnnotationAttributeParser::parseBooleanValue($attributes['value']['lazy']);
             }
 
-            if (isset($attributes['value']['aliases'])) {
-                $this->aliases = $attributes['value']['aliases'];
+            if (isset($attributes['value']['aliases']) and is_array($attributes['value']['aliases'])) {
+                $this->setAliases(...$attributes['value']['aliases']);
             }
 
-            if (isset($attributes['value']['parameters'])) {
-                $this->parameters = $attributes['value']['parameters'];
+            if (isset($attributes['value']['parameters']) and is_array($attributes['value']['parameters'])) {
+                $this->setParameters(...$attributes['value']['parameters']);
             }
         }
     }
@@ -95,7 +91,7 @@ final class Bean
      *
      * @return bool
      */
-    public function isRequest() : bool
+    public function isRequest(): bool
     {
         return $this->scope === self::SCOPE_REQUEST;
     }
@@ -105,7 +101,7 @@ final class Bean
      *
      * @return bool
      */
-    public function isSession() : bool
+    public function isSession(): bool
     {
         return $this->scope === self::SCOPE_SESSION;
     }
@@ -115,7 +111,7 @@ final class Bean
      *
      * @return bool
      */
-    public function isSingleton() : bool
+    public function isSingleton(): bool
     {
         return $this->singleton;
     }
@@ -125,7 +121,7 @@ final class Bean
      *
      * @return bool
      */
-    public function isLazy() : bool
+    public function isLazy(): bool
     {
         return $this->lazy;
     }
@@ -141,12 +137,12 @@ final class Bean
     }
 
     /**
-     * Returns the list of parameters for the bean instance. Returns an empty array when no parameters were set.
+     * Helper methd to ensure that the passed aliases are of {@link \bitExpert\Disco\Annotations\Alias} type.
      *
-     * @return Parameter[]
+     * @param Alias[] $aliases
      */
-    public function getParameters(): array
+    private function setAliases(Alias ...$aliases): void
     {
-        return $this->parameters;
+        $this->aliases = $aliases;
     }
 }

--- a/src/bitExpert/Disco/Annotations/BeanPostProcessor.php
+++ b/src/bitExpert/Disco/Annotations/BeanPostProcessor.php
@@ -12,10 +12,34 @@ declare(strict_types=1);
 
 namespace bitExpert\Disco\Annotations;
 
+use Doctrine\Common\Annotations\Annotation\Attribute;
+use Doctrine\Common\Annotations\Annotation\Attributes;
+use Doctrine\Common\Annotations\AnnotationException;
+
 /**
  * @Annotation
  * @Target({"METHOD"})
+ * @Attributes({
+ *   @Attribute("parameters", type = "array<\bitExpert\Disco\Annotations\Parameter>")
+ * })
  */
-final class BeanPostProcessor
+final class BeanPostProcessor extends ParameterAwareAnnotation
 {
+
+    /**
+     * Creates a new {@link \bitExpert\Disco\Annotations\BeanPostProcessor}.
+     *
+     * @param array $attributes
+     * @throws AnnotationException
+     */
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct();
+
+        if (isset($attributes['value'], $attributes['value']['parameters']) and
+            is_array($attributes['value']['parameters'])
+        ) {
+            $this->setParameters(...$attributes['value']['parameters']);
+        }
+    }
 }

--- a/src/bitExpert/Disco/Annotations/ParameterAwareAnnotation.php
+++ b/src/bitExpert/Disco/Annotations/ParameterAwareAnnotation.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Disco package.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace bitExpert\Disco\Annotations;
+
+/**
+ * Base class for all annotations that are parameter-aware.
+ */
+abstract class ParameterAwareAnnotation
+{
+    /**
+     * @var Parameter[]
+     */
+    private $parameters;
+
+    /**
+     * Creates a new {@link \bitExpert\Disco\Annotations\ParameterAwareAnnotation}.
+     */
+    public function __construct()
+    {
+        $this->parameters = [];
+    }
+
+    /**
+     * Returns the list of parameters for the bean post processor instance. Returns an empty array when no parameters
+     * were set.
+     *
+     * @return Parameter[]
+     */
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+
+    /**
+     * Helper methd to ensure that the passed parameters are of {@link \bitExpert\Disco\Annotations\Parameter} type.
+     *
+     * @param Parameter[] ...$parameters
+     */
+    protected function setParameters(Parameter ...$parameters): void
+    {
+        $this->parameters = $parameters;
+    }
+}

--- a/src/bitExpert/Disco/Proxy/Configuration/MethodGenerator/BeanMethod.php
+++ b/src/bitExpert/Disco/Proxy/Configuration/MethodGenerator/BeanMethod.php
@@ -13,8 +13,6 @@ declare(strict_types = 1);
 namespace bitExpert\Disco\Proxy\Configuration\MethodGenerator;
 
 use bitExpert\Disco\Annotations\Bean;
-use bitExpert\Disco\Annotations\Parameter;
-use bitExpert\Disco\Annotations\Parameters;
 use bitExpert\Disco\BeanException;
 use bitExpert\Disco\InitializedBean;
 use bitExpert\Disco\Proxy\Configuration\PropertyGenerator\BeanFactoryConfigurationProperty;
@@ -23,9 +21,9 @@ use bitExpert\Disco\Proxy\Configuration\PropertyGenerator\ForceLazyInitProperty;
 use bitExpert\Disco\Proxy\Configuration\PropertyGenerator\SessionBeansProperty;
 use bitExpert\Disco\Proxy\LazyBean\LazyBeanFactory;
 use ProxyManager\Exception\InvalidProxiedClassException;
-use ProxyManager\Generator\MethodGenerator;
 use ProxyManager\Proxy\LazyLoadingInterface;
 use ReflectionType;
+use Zend\Code\Generator\MethodGenerator;
 use Zend\Code\Generator\ParameterGenerator;
 use Zend\Code\Reflection\MethodReflection;
 
@@ -35,7 +33,7 @@ use Zend\Code\Reflection\MethodReflection;
  * as taking the configuration options like lazy creation or session-awareness of the bean into
  * account. These configuration options are defined via annotations.
  */
-class BeanMethod extends MethodGenerator
+class BeanMethod extends ParameterAwareMethodGenerator
 {
     /**
      * Creates a new {@link \bitExpert\Disco\Proxy\Configuration\MethodGenerator\BeanMethod}.
@@ -49,7 +47,7 @@ class BeanMethod extends MethodGenerator
      * @param BeanFactoryConfigurationProperty $beanFactoryConfigurationProperty
      * @param GetParameter $parameterValuesMethod
      * @param WrapBeanAsLazy $wrapBeanAsLazy
-     * @return BeanMethod|MethodGenerator
+     * @return MethodGenerator
      * @throws \Zend\Code\Generator\Exception\InvalidArgumentException
      * @throws \ProxyManager\Exception\InvalidProxiedClassException
      */
@@ -148,44 +146,6 @@ class BeanMethod extends MethodGenerator
         }
 
         return $method;
-    }
-
-    /**
-     * Converts the Parameter annotations to the respective getParameter() method calls to retrieve the configuration
-     * values.
-     *
-     * @param Parameters $methodParameters
-     * @param GetParameter $parameterValuesMethod
-     * @return string
-     */
-    protected static function convertMethodParamsToString(
-        array $methodParameters,
-        GetParameter $parameterValuesMethod
-    ) : string {
-        $parameters = [];
-        foreach ($methodParameters as $methodParameter) {
-            /** @var $methodParameter Parameter */
-            $name = $methodParameter->getName();
-            $defaultValue = $methodParameter->getDefaultValue();
-            $required = $methodParameter->isRequired() ? 'true' : 'false';
-            if (is_string($defaultValue)) {
-                $defaultValue = '"' . $defaultValue . '"';
-            } elseif (is_null($defaultValue)) {
-                $defaultValue = 'null';
-            } elseif (is_bool($defaultValue)) {
-                $defaultValue = ($defaultValue) ? 'true' : 'false';
-            }
-
-            if (!empty($defaultValue)) {
-                $parameters[] = '$this->' . $parameterValuesMethod->getName() . '("' . $name . '", ' . $required .
-                    ', ' . $defaultValue . ')';
-            } else {
-                $parameters[] = '$this->' . $parameterValuesMethod->getName() . '("' . $name . '", ' . $required .
-                    ')';
-            }
-        }
-
-        return implode(', ', $parameters);
     }
 
     /**

--- a/src/bitExpert/Disco/Proxy/Configuration/MethodGenerator/BeanPostProcessorMethod.php
+++ b/src/bitExpert/Disco/Proxy/Configuration/MethodGenerator/BeanPostProcessorMethod.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Disco package.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+declare(strict_types = 1);
+
+namespace bitExpert\Disco\Proxy\Configuration\MethodGenerator;
+
+use bitExpert\Disco\Annotations\BeanPostProcessor;
+use Zend\Code\Generator\MethodGenerator;
+use Zend\Code\Reflection\MethodReflection;
+
+class BeanPostProcessorMethod extends ParameterAwareMethodGenerator
+{
+    /**
+     * Creates a new {@link \bitExpert\Disco\Proxy\Configuration\MethodGenerator\BeanPostProcessorMethod}.
+     *
+     * @param MethodReflection $originalMethod
+     * @param BeanPostProcessor $beanPostProcessorMetadata
+     * @param GetParameter $parameterValuesMethod
+     * @return MethodGenerator
+     * @throws \Zend\Code\Generator\Exception\InvalidArgumentException
+     */
+    public static function generateMethod(
+        MethodReflection $originalMethod,
+        BeanPostProcessor $beanPostProcessorMetadata,
+        GetParameter $parameterValuesMethod
+    ) {
+        $method = static::fromReflection($originalMethod);
+
+        $methodParams = static::convertMethodParamsToString(
+            $beanPostProcessorMetadata->getParameters(),
+            $parameterValuesMethod
+        );
+        $beanId = $originalMethod->name;
+        $body = 'return parent::' . $beanId . '(' . $methodParams . ');' . PHP_EOL;
+
+        $method->setBody($body);
+        $method->setDocBlock('{@inheritDoc}');
+        return $method;
+    }
+}

--- a/src/bitExpert/Disco/Proxy/Configuration/MethodGenerator/ParameterAwareMethodGenerator.php
+++ b/src/bitExpert/Disco/Proxy/Configuration/MethodGenerator/ParameterAwareMethodGenerator.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Disco package.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+declare(strict_types = 1);
+
+namespace bitExpert\Disco\Proxy\Configuration\MethodGenerator;
+
+use bitExpert\Disco\Annotations\Parameter;
+use Zend\Code\Generator\MethodGenerator;
+
+/**
+ * Base class for all annotations that are parameter-aware.
+ */
+class ParameterAwareMethodGenerator extends MethodGenerator
+{
+    /**
+     * Converts the Parameter annotations to the respective getParameter() method calls to retrieve the configuration
+     * values.
+     *
+     * @param Parameter[] $methodParameters
+     * @param GetParameter $parameterValuesMethod
+     * @return string
+     */
+    protected static function convertMethodParamsToString(
+        array $methodParameters,
+        GetParameter $parameterValuesMethod
+    ) : string {
+        $parameters = [];
+        foreach ($methodParameters as $methodParameter) {
+            /** @var $methodParameter Parameter */
+            $name = $methodParameter->getName();
+            $defaultValue = $methodParameter->getDefaultValue();
+            $required = $methodParameter->isRequired() ? 'true' : 'false';
+            if (is_string($defaultValue)) {
+                $defaultValue = '"' . $defaultValue . '"';
+            } elseif (is_null($defaultValue)) {
+                $defaultValue = 'null';
+            } elseif (is_bool($defaultValue)) {
+                $defaultValue = ($defaultValue) ? 'true' : 'false';
+            }
+
+            if (!empty($defaultValue)) {
+                $parameters[] = '$this->' . $parameterValuesMethod->getName() . '("' . $name . '", ' . $required .
+                    ', ' . $defaultValue . ')';
+            } else {
+                $parameters[] = '$this->' . $parameterValuesMethod->getName() . '("' . $name . '", ' . $required .
+                    ')';
+            }
+        }
+
+        return implode(', ', $parameters);
+    }
+}

--- a/tests/bitExpert/Disco/AnnotationBeanFactoryUnitTest.php
+++ b/tests/bitExpert/Disco/AnnotationBeanFactoryUnitTest.php
@@ -19,6 +19,7 @@ use bitExpert\Disco\Config\BeanConfigurationWithAliases;
 use bitExpert\Disco\Config\BeanConfigurationWithParameterizedPostProcessor;
 use bitExpert\Disco\Config\BeanConfigurationWithParameters;
 use bitExpert\Disco\Config\BeanConfigurationWithPostProcessor;
+use bitExpert\Disco\Config\BeanConfigurationWithPostProcessorAndParameterizedDependency;
 use bitExpert\Disco\Config\BeanConfigurationWithPrimitives;
 use bitExpert\Disco\Config\BeanConfigurationWithProtectedMethod;
 use bitExpert\Disco\Config\WrongReturnTypeConfiguration;
@@ -266,10 +267,26 @@ class AnnotationBeanFactoryUnitTest extends TestCase
     /**
      * @test
      */
-    public function beanFactoryPostProcessorIsInitializedAfterParametersAreSet()
+    public function beanFactoryPostProcessorAcceptsParameters()
     {
         $this->beanFactory = new AnnotationBeanFactory(
             BeanConfigurationWithParameterizedPostProcessor::class,
+            ['test' => 'injectedValue']
+        );
+        BeanFactoryRegistry::register($this->beanFactory);
+
+        /** @var SampleService $bean */
+        $bean = $this->beanFactory->get('nonSingletonNonLazyRequestBean');
+        self::assertEquals('injectedValue', $bean->test);
+    }
+
+    /**
+     * @test
+     */
+    public function beanFactoryPostProcessorCanBeConfiguredWithParameterizedDependency()
+    {
+        $this->beanFactory = new AnnotationBeanFactory(
+            BeanConfigurationWithPostProcessorAndParameterizedDependency::class,
             ['test' => 'injectedValue']
         );
         BeanFactoryRegistry::register($this->beanFactory);

--- a/tests/bitExpert/Disco/Annotations/BeanPostProcessorUnitTest.php
+++ b/tests/bitExpert/Disco/Annotations/BeanPostProcessorUnitTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Disco package.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace bitExpert\Disco\Annotations;
+
+use bitExpert\Disco\Helper\SampleService;
+use PHPUnit\Framework\TestCase;
+use TypeError;
+
+/**
+ * Unit tests for {@link \bitExpert\Disco\Annotations\BeanPostProcessorUnitTest}.
+ */
+class BeanPostProcessorUnitTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function configuredParametersGetReturned()
+    {
+        $bean = new Bean(['value' => ['parameters' => [
+            new Parameter(['value' => ['name' => 'parameterName']]),
+            new Parameter(['value' => ['name' => 'yetAnotherParameter']])
+        ]]]);
+
+        self::assertEquals(array_map(function (Parameter $parameter) {
+            return $parameter->getName();
+        }, $bean->getParameters()), ['parameterName', 'yetAnotherParameter']);
+    }
+
+    /**
+     * @test
+     * @expectedException TypeError
+     */
+    public function throwsExceptionIfParameterTypeDoesNotMatch()
+    {
+        $bean = new Bean(['value' => ['parameters' => [
+            new SampleService()
+        ]]]);
+    }
+}

--- a/tests/bitExpert/Disco/Annotations/BeanUnitTest.php
+++ b/tests/bitExpert/Disco/Annotations/BeanUnitTest.php
@@ -12,7 +12,9 @@ declare(strict_types=1);
 
 namespace bitExpert\Disco\Annotations;
 
+use bitExpert\Disco\Helper\SampleService;
 use PHPUnit\Framework\TestCase;
+use TypeError;
 
 /**
  * Unit tests for {@link \bitExpert\Disco\Annotations\Bean}.
@@ -31,6 +33,7 @@ class BeanUnitTest extends TestCase
         self::assertTrue($bean->isSingleton());
         self::assertFalse($bean->isLazy());
         self::assertEmpty($bean->getAliases());
+        self::assertEmpty($bean->getParameters());
     }
 
     /**
@@ -178,7 +181,7 @@ class BeanUnitTest extends TestCase
     /**
      * @test
      */
-    public function aliasingBean()
+    public function configuredAliasesGetReturned()
     {
         $bean = new Bean(['value' => ['aliases' => [
             new Alias(['value' => ['name' => 'someAlias']]),
@@ -188,5 +191,42 @@ class BeanUnitTest extends TestCase
         self::assertEquals(array_map(function (Alias $alias) {
             return $alias->getName();
         }, $bean->getAliases()), ['someAlias', 'yetAnotherAlias']);
+    }
+
+    /**
+     * @test
+     * @expectedException TypeError
+     */
+    public function throwsExceptionIfAliasTypeDoesNotMatch()
+    {
+        $bean = new Bean(['value' => ['aliases' => [
+            new SampleService()
+        ]]]);
+    }
+
+    /**
+     * @test
+     */
+    public function configuredParametersGetReturned()
+    {
+        $bean = new Bean(['value' => ['parameters' => [
+            new Parameter(['value' => ['name' => 'parameterName']]),
+            new Parameter(['value' => ['name' => 'yetAnotherParameter']])
+        ]]]);
+
+        self::assertEquals(array_map(function (Parameter $parameter) {
+            return $parameter->getName();
+        }, $bean->getParameters()), ['parameterName', 'yetAnotherParameter']);
+    }
+
+    /**
+     * @test
+     * @expectedException TypeError
+     */
+    public function throwsExceptionIfParameterTypeDoesNotMatch()
+    {
+        $bean = new Bean(['value' => ['parameters' => [
+            new SampleService()
+        ]]]);
     }
 }

--- a/tests/bitExpert/Disco/Config/BeanConfigurationWithPostProcessorAndParameterizedDependency.php
+++ b/tests/bitExpert/Disco/Config/BeanConfigurationWithPostProcessorAndParameterizedDependency.php
@@ -22,18 +22,14 @@ use bitExpert\Disco\Helper\SampleService;
 /**
  * @Configuration
  */
-class BeanConfigurationWithParameterizedPostProcessor
+class BeanConfigurationWithPostProcessorAndParameterizedDependency
 {
     /**
-     * @BeanPostProcessor({
-     *   "parameters"={
-     *      @Parameter({"name" = "test"})
-     *   }
-     * })
+     * @BeanPostProcessor
      */
-    public function sampleServiceBeanPostProcessor($test = ''): ParameterizedSampleServiceBeanPostProcessor
+    public function sampleServiceBeanPostProcessor(): ParameterizedSampleServiceBeanPostProcessor
     {
-        return new ParameterizedSampleServiceBeanPostProcessor($test);
+        return new ParameterizedSampleServiceBeanPostProcessor($this->dependency());
     }
 
     /**
@@ -42,5 +38,19 @@ class BeanConfigurationWithParameterizedPostProcessor
     public function nonSingletonNonLazyRequestBean(): SampleService
     {
         return new SampleService();
+    }
+
+    /**
+     * @Bean({
+     *   "parameters"={
+     *      @Parameter({"name" = "test"})
+     *   }
+     * })
+     */
+    public function dependency($test = ''): \stdClass
+    {
+        $object = new \stdClass();
+        $object->property = $test;
+        return $object;
     }
 }


### PR DESCRIPTION
Allow passing parameters to the BeanPostProcessor configuration in a similar fashion as passing parameters to the Bean configuration.