### PR TITLE
Add "provide" section to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,10 @@
       "bitExpert\\Disco\\": ["tests/bitExpert/Disco", "benchmarks/bitExpert/Disco"]
     }
   },
+  "provide": {
+    "container-interop/container-interop-implementation": "^1.2",
+    "psr/container-implementation": "^1.0"
+  },
   "scripts": {
     "check": [
       "@cs-check",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "e9e5c5bfc2c1d920e23f1bed720c7537",
+    "content-hash": "2ba493737278d31f7acdee1a46084688",
     "packages": [
         {
             "name": "bitexpert/slf4psrlog",
@@ -879,7 +879,7 @@
                 "markdown",
                 "static site"
             ],
-            "time": "2016-03-04 17:42:57"
+            "time": "2016-03-04T17:42:57+00:00"
         },
         {
             "name": "cilex/cilex",


### PR DESCRIPTION
To clearly communicate that Disco provides a PSR-11 container the "provide" section is added to the composer.json file.