### PR TITLE
Add test for invalid service alias names

### DIFF
--- a/tests/bitExpert/Disco/Annotations/AliasUnitTest.php
+++ b/tests/bitExpert/Disco/Annotations/AliasUnitTest.php
@@ -61,4 +61,27 @@ class AliasUnitTest extends TestCase
         self::expectExceptionMessage('Alias should either be a named alias or a type alias!');
         new Alias();
     }
+
+    /**
+     * @test
+     * @dataProvider invalidNameProvider
+     */
+    public function aliasNameCannotBeEmpty($name)
+    {
+        self::expectException(AnnotationException::class);
+        self::expectExceptionMessage('Alias should either be a named alias or a type alias!');
+        new Alias(['value' => ['name' => $name, 'type' => false]]);
+    }
+
+    public function invalidNameProvider()
+    {
+        return [
+            [''],
+            [0],
+            [0.0],
+            [false],
+            [null],
+            [[]],
+        ];
+    }
 }


### PR DESCRIPTION
I've added a test to cover invalid service aliases that I missed during #96. With this test, I want to prevent, that a refactoring can open a gap for an invalid naming in an alias.