### PR TITLE
Remove VersionEye badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 This package provides a [PSR-11](http://www.php-fig.org/psr/psr-11/) compatible, annotation-based dependency injection container. Have a look at the [disco-demos](https://github.com/bitExpert/disco-demos) project to find out how to use Disco.
 
 [![Build Status](https://travis-ci.org/bitExpert/disco.svg?branch=master)](https://travis-ci.org/bitExpert/disco)
-[![Dependency Status](https://www.versioneye.com/user/projects/563e5b144d415e0018000121/badge.svg?style=flat)](https://www.versioneye.com/user/projects/563e5b144d415e0018000121)
 [![Coverage Status](https://coveralls.io/repos/github/bitExpert/disco/badge.svg?branch=master)](https://coveralls.io/github/bitExpert/disco?branch=master)
 
 ## Installation


### PR DESCRIPTION
It's a sad task, but versioneye will end this year :-( and this PR is about removing the VersionEye badge from the readme file.

More information about the VersionEye sunset process:
https://blog.versioneye.com/2017/10/19/versioneye-sunset-process/