### PR TITLE
Missing types for Disco methods

### DIFF
--- a/docs/advanced/bean-post-processor.md
+++ b/docs/advanced/bean-post-processor.md
@@ -15,7 +15,7 @@ class SampleServiceBeanPostProcessor implements \bitExpert\Disco\BeanPostProcess
     /**
      * {@inheritdoc}
      */
-    public function postProcess($bean, $beanName)
+    public function postProcess(object $bean, string $beanName): void
     {
         if ($bean instanceof SampleService) {
             $bean->setTest('Set by Bean Post Processor!');

--- a/src/bitExpert/Disco/BeanFactoryConfiguration.php
+++ b/src/bitExpert/Disco/BeanFactoryConfiguration.php
@@ -77,7 +77,7 @@ class BeanFactoryConfiguration
      * @param string $proxyTargetDir
      * @throws InvalidArgumentException
      */
-    public function setProxyTargetDir(string $proxyTargetDir)
+    public function setProxyTargetDir(string $proxyTargetDir): void
     {
         if (!is_dir($proxyTargetDir)) {
             throw new InvalidArgumentException(
@@ -108,7 +108,7 @@ class BeanFactoryConfiguration
      *
      * @param GeneratorStrategyInterface $writergenerator
      */
-    public function setProxyWriterGenerator(GeneratorStrategyInterface $writergenerator)
+    public function setProxyWriterGenerator(GeneratorStrategyInterface $writergenerator): void
     {
         $this->proxyWriterGenerator = $writergenerator;
     }
@@ -120,7 +120,7 @@ class BeanFactoryConfiguration
      * @param AutoloaderInterface $autoloader
      * @throws \RuntimeException
      */
-    public function setProxyAutoloader(AutoloaderInterface $autoloader)
+    public function setProxyAutoloader(AutoloaderInterface $autoloader): void
     {
         if ($this->proxyAutoloader instanceof AutoloaderInterface) {
             spl_autoload_unregister($this->proxyAutoloader);
@@ -170,7 +170,7 @@ class BeanFactoryConfiguration
      *
      * @param BeanStore $sessionBeanStore
      */
-    public function setSessionBeanStore(BeanStore $sessionBeanStore)
+    public function setSessionBeanStore(BeanStore $sessionBeanStore): void
     {
         $this->sessionBeanStore = $sessionBeanStore;
     }

--- a/src/bitExpert/Disco/BeanPostProcessor.php
+++ b/src/bitExpert/Disco/BeanPostProcessor.php
@@ -26,5 +26,5 @@ interface BeanPostProcessor
      * @param object $bean
      * @param string $beanName
      */
-    public function postProcess($bean, $beanName);
+    public function postProcess(object $bean, string $beanName): void;
 }

--- a/src/bitExpert/Disco/InitializedBean.php
+++ b/src/bitExpert/Disco/InitializedBean.php
@@ -26,5 +26,5 @@ interface InitializedBean
      *
      * @throws \bitExpert\Disco\BeanException
      */
-    public function postInitialization();
+    public function postInitialization(): void;
 }

--- a/src/bitExpert/Disco/Proxy/Configuration/ConfigurationFactory.php
+++ b/src/bitExpert/Disco/Proxy/Configuration/ConfigurationFactory.php
@@ -46,8 +46,11 @@ class ConfigurationFactory extends AbstractBaseFactory
      * @param array $parameters
      * @return object
      */
-    public function createInstance(BeanFactoryConfiguration $config, $configClassName, array $parameters = [])
-    {
+    public function createInstance(
+        BeanFactoryConfiguration $config,
+        string $configClassName,
+        array $parameters = []
+    ): object {
         $proxyClassName = $this->generateProxy($configClassName);
         return new $proxyClassName($config, $parameters);
     }

--- a/src/bitExpert/Disco/Proxy/Configuration/MethodGenerator/BeanMethod.php
+++ b/src/bitExpert/Disco/Proxy/Configuration/MethodGenerator/BeanMethod.php
@@ -61,7 +61,7 @@ class BeanMethod extends ParameterAwareMethodGenerator
         BeanFactoryConfigurationProperty $beanFactoryConfigurationProperty,
         GetParameter $parameterValuesMethod,
         WrapBeanAsLazy $wrapBeanAsLazy
-    ) {
+    ): MethodGenerator {
         if (null === $beanType) {
             throw new InvalidProxiedClassException(
                 sprintf(

--- a/src/bitExpert/Disco/Proxy/Configuration/MethodGenerator/BeanPostProcessorMethod.php
+++ b/src/bitExpert/Disco/Proxy/Configuration/MethodGenerator/BeanPostProcessorMethod.php
@@ -31,7 +31,7 @@ class BeanPostProcessorMethod extends ParameterAwareMethodGenerator
         MethodReflection $originalMethod,
         BeanPostProcessor $beanPostProcessorMetadata,
         GetParameter $parameterValuesMethod
-    ) {
+    ): MethodGenerator {
         $method = static::fromReflection($originalMethod);
 
         $methodParams = static::convertMethodParamsToString(

--- a/src/bitExpert/Disco/Proxy/LazyBean/LazyBeanFactory.php
+++ b/src/bitExpert/Disco/Proxy/LazyBean/LazyBeanFactory.php
@@ -45,9 +45,12 @@ class LazyBeanFactory extends AbstractBaseFactory
     }
 
     /**
-     * {@inheritDoc}
+     * @param string  $className
+     * @param Closure $initializer
+     *
+     * @return object
      */
-    public function createProxy($className, Closure $initializer)
+    public function createProxy(string $className, Closure $initializer): object
     {
         $proxyClassName = $this->generateProxy($className);
 

--- a/src/bitExpert/Disco/Store/BeanStore.php
+++ b/src/bitExpert/Disco/Store/BeanStore.php
@@ -22,7 +22,7 @@ interface BeanStore
      * @param string $beanId
      * @param mixed $bean
      */
-    public function add(string $beanId, $bean);
+    public function add(string $beanId, $bean): void;
 
     /**
      * Retrieves bean instance for $beanId.

--- a/src/bitExpert/Disco/Store/SerializableBeanStore.php
+++ b/src/bitExpert/Disco/Store/SerializableBeanStore.php
@@ -34,7 +34,7 @@ class SerializableBeanStore implements BeanStore
     /**
      * {@inheritdoc}
      */
-    public function add(string $beanId, $bean)
+    public function add(string $beanId, $bean): void
     {
         $this->beans[$beanId] = $bean;
     }

--- a/tests/bitExpert/Disco/Helper/InitializedService.php
+++ b/tests/bitExpert/Disco/Helper/InitializedService.php
@@ -26,7 +26,7 @@ class InitializedService implements InitializedBean
     /**
      * {@inheritDoc}
      */
-    public function postInitialization()
+    public function postInitialization(): void
     {
         $this->postInitCnt++;
     }

--- a/tests/bitExpert/Disco/Helper/ParameterizedSampleServiceBeanPostProcessor.php
+++ b/tests/bitExpert/Disco/Helper/ParameterizedSampleServiceBeanPostProcessor.php
@@ -31,7 +31,7 @@ class ParameterizedSampleServiceBeanPostProcessor implements BeanPostProcessor
     /**
      * {@inheritDoc}
      */
-    public function postProcess($bean, $beanName)
+    public function postProcess(object $bean, string $beanName): void
     {
         if ($bean instanceof SampleService) {
             $bean->setTest($this->dependency);

--- a/tests/bitExpert/Disco/Helper/SampleServiceBeanPostProcessor.php
+++ b/tests/bitExpert/Disco/Helper/SampleServiceBeanPostProcessor.php
@@ -19,7 +19,7 @@ class SampleServiceBeanPostProcessor implements BeanPostProcessor
     /**
      * {@inheritDoc}
      */
-    public function postProcess($bean, $beanName)
+    public function postProcess(object $bean, string $beanName): void
     {
         if ($bean instanceof SampleService) {
             $bean->setTest('postProcessed');


### PR DESCRIPTION
As mentioned in #114, there are a few missing types for Disco methods that I added with this PR. It is a BC break in case methods were overridden by other classes in projects using Disco.