### PR TITLE
Allow overwriting an Alias in an extending class

### DIFF
--- a/src/bitExpert/Disco/Proxy/Configuration/ConfigurationGenerator.php
+++ b/src/bitExpert/Disco/Proxy/Configuration/ConfigurationGenerator.php
@@ -148,7 +148,7 @@ class ConfigurationGenerator implements ProxyGeneratorInterface
                     continue;
                 }
 
-                if (isset($aliases[$alias]) && $declaringClass[$alias] == $method->getDeclaringClass() ) {
+                if (isset($aliases[$alias]) && $declaringClass[$alias] == $method->getDeclaringClass()) {
                     throw new InvalidProxiedClassException(
                         sprintf(
                             'Alias "%s" of method "%s" on "%s" is already used by method "%s" of another Bean!'
@@ -162,7 +162,10 @@ class ConfigurationGenerator implements ProxyGeneratorInterface
                 }
 
                 $extendedClass = $method->getDeclaringClass()->getExtension();
-                if (isset($declaringClass[$alias]) && $extendedClass && ! in_array($declaringClass[$alias], $extendedClass->getClasses())) {
+                if (isset($declaringClass[$alias]) &&
+                    $extendedClass &&
+                    ! in_array($declaringClass[$alias], $extendedClass->getClasses())
+                ) {
                     // The alias is not overwriting the alias-definition of an extended class, so it is silently ignored
                     continue;
                 }

--- a/tests/bitExpert/Disco/Config/BeanConfigurationWithExtendedAliases.php
+++ b/tests/bitExpert/Disco/Config/BeanConfigurationWithExtendedAliases.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Disco package.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace bitExpert\Disco\Config;
+
+use bitExpert\Disco\Annotations\Alias;
+use bitExpert\Disco\Annotations\Bean;
+use bitExpert\Disco\Annotations\Configuration;
+use bitExpert\Disco\Helper\SampleService;
+use bitExpert\Disco\Helper\SampleServiceInterface;
+
+/**
+ * @Configuration
+ */
+class BeanConfigurationWithExtendedAliases extends BeanConfigurationWithAliases
+{
+
+
+    /**
+     * @Bean({
+     *   "aliases"={
+     *     @Alias({"type"=true})
+     *   }
+     * })
+     * @return SampleServiceInterface
+     */
+    public function extendedSampleServiceWithInterfaceReturnTypeAlias(): SampleServiceInterface
+    {
+        return new SampleService();
+    }
+}

--- a/tests/bitExpert/Disco/Proxy/Configuration/ConfigurationGeneratorUnitTest.php
+++ b/tests/bitExpert/Disco/Proxy/Configuration/ConfigurationGeneratorUnitTest.php
@@ -14,6 +14,7 @@ namespace bitExpert\Disco\Proxy\Configuration;
 
 use bitExpert\Disco\Config\BeanConfiguration;
 use bitExpert\Disco\Config\BeanConfigurationWithConflictingAliases;
+use bitExpert\Disco\Config\BeanConfigurationWithExtendedAliases;
 use bitExpert\Disco\Config\BeanConfigurationWithNativeTypeAlias;
 use bitExpert\Disco\Config\InterfaceConfiguration;
 use bitExpert\Disco\Config\InvalidConfiguration;
@@ -148,6 +149,18 @@ class ConfigurationGeneratorUnitTest extends TestCase
             ->method('addMethodFromGenerator');
 
         $reflClass = new \ReflectionClass(BeanConfiguration::class);
+        $this->configGenerator->generate($reflClass, $this->classGenerator);
+    }
+
+    /**
+     * @test
+     */
+    public function parsingExtendingFileWithSameAliasSucceeds()
+    {
+        $this->classGenerator->expects(self::atLeastOnce())
+                             ->method('addMethodFromGenerator');
+
+        $reflClass = new \ReflectionClass(BeanConfigurationWithExtendedAliases::class);
         $this->configGenerator->generate($reflClass, $this->classGenerator);
     }
 }


### PR DESCRIPTION
Currently Disco throws an exception when it finds an already declared alias. That is totally valid as long as the configuration is done in one single file.

As soon as you want to have a configuration split over different files that becomes complicated as you can not overwrite an alias that was declared in the base class within an extending class.

Given I want a configuration for my production system with an alias for a logger and I then want to extend that configuration for my dev-environment and want to implement a different logger.

Currently I need to create three classes. One base class with all the configs that will never change and one class for production config extending the base class and implementing all the aliases that will change between prod and dev. And I also create another config for the dev-counterpart of those changing aliases.

This commit allows to overwrite aliases in extending files only. So I can create my configuration for production and for dev I can extend that base class and overwrite the aliases I need to adapt.

This change should be absolute BC, no tests where adapted, only added.