### PR TITLE
Set php stan level to max

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ script:
     - ./vendor/bin/phing sniff
     - if [[ $TEST_COVERAGE == 'true' ]]; then ./vendor/bin/phing unit-with-coverage ; fi
     - if [[ $TEST_COVERAGE != 'true' ]]; then ./vendor/bin/phing unit ; fi
+    - composer analyze
 
 after_script:
     - if [[ $TEST_COVERAGE == 'true' ]]; then ./vendor/bin/coveralls -v ; fi

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "psr/container": "^1.0.0",
     "doctrine/annotations": "^1.3.0",
     "ocramius/proxy-manager": "^2.2.0",
-    "bitexpert/slf4psrlog": "^0.1.3"
+    "bitexpert/slf4psrlog": "^0.1.3",
+    "tm/tooly-composer-script": "^1.2"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.1.3",
@@ -49,6 +50,17 @@
     ],
     "cs-check": "vendor/bin/phing sniff",
     "cs-fix": "vendor/bin/phpcbf",
-    "test": "vendor/bin/phing unit"
+    "test": "vendor/bin/phing unit",
+    "analyze": "vendor/bin/phpstan.phar analyze -l 0  ./src .tests",
+    "post-install-cmd": "Tooly\\ScriptHandler::installPharTools",
+    "post-update-cmd": "Tooly\\ScriptHandler::installPharTools"
+  },
+  "extra": {
+    "tools": {
+      "phpstan": {
+        "url": "https://api.getlatestassets.com/github/phpstan/phpstan/phpstan.phar?version=^0.10",
+        "sign-url": "https://api.getlatestassets.com/github/phpstan/phpstan/phpstan.phar.asc?version=^0.10"
+      }
+    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
     "cs-check": "vendor/bin/phing sniff",
     "cs-fix": "vendor/bin/phpcbf",
     "test": "vendor/bin/phing unit",
-    "analyze": "vendor/bin/phpstan.phar analyze -l 0  ./src .tests",
+    "analyze": "vendor/bin/phpstan.phar analyze -l 0  ./src ./tests",
     "post-install-cmd": "Tooly\\ScriptHandler::installPharTools",
     "post-update-cmd": "Tooly\\ScriptHandler::installPharTools"
   },

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
     "cs-check": "vendor/bin/phing sniff",
     "cs-fix": "vendor/bin/phpcbf",
     "test": "vendor/bin/phing unit",
-    "analyze": "vendor/bin/phpstan.phar analyze -l 0  ./src ./tests",
+    "analyze": "vendor/bin/phpstan.phar analyze || true" ,
     "post-install-cmd": "Tooly\\ScriptHandler::installPharTools",
     "post-update-cmd": "Tooly\\ScriptHandler::installPharTools"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bbccf72d57e0079f4f6f3bbb7cb0f4a8",
+    "content-hash": "dee9d3bab67174c92d8537c8faa343bc",
     "packages": [
         {
             "name": "bitexpert/slf4psrlog",
@@ -388,6 +388,86 @@
                 "psr-3"
             ],
             "time": "2016-10-10T12:19:37+00:00"
+        },
+        {
+            "name": "tm/tooly-composer-script",
+            "version": "1.2.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/tommy-muehle/tooly-composer-script.git",
+                "reference": "53cc0551122145b4ae4c523e64f3628329ef8ea5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/tommy-muehle/tooly-composer-script/zipball/53cc0551122145b4ae4c523e64f3628329ef8ea5",
+                "reference": "53cc0551122145b4ae4c523e64f3628329ef8ea5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "codeclimate/php-test-reporter": "dev-master",
+                "composer/composer": "1.*",
+                "mikey179/vfsstream": "1.6.*",
+                "php-mock/php-mock-phpunit": "1.1.*",
+                "symfony/console": "^3.0",
+                "tm/gpg-verifier": "1.*"
+            },
+            "suggest": {
+                "tm/gpg-verifier": "Allows verification over GPG for PHAR tools."
+            },
+            "type": "library",
+            "extra": {
+                "tools": {
+                    "phpunit": {
+                        "url": "https://phar.phpunit.de/phpunit-5.5.0.phar"
+                    },
+                    "phpcpd": {
+                        "url": "https://phar.phpunit.de/phpcpd-2.0.4.phar"
+                    },
+                    "phpcs": {
+                        "url": "https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar",
+                        "force-replace": true
+                    },
+                    "phpmd": {
+                        "url": "http://static.phpmd.org/php/latest/phpmd.phar",
+                        "force-replace": true
+                    },
+                    "security-checker": {
+                        "url": "http://get.sensiolabs.org/security-checker.phar",
+                        "force-replace": true
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Tooly\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tommy Muehle",
+                    "email": "tommy.muehle@gmail.com",
+                    "homepage": "https://tommy-muehle.de"
+                }
+            ],
+            "description": "Simple composer script to manage phar files.",
+            "homepage": "https://github.com/tommy-muehle/tooly-composer-script",
+            "keywords": [
+                "composer",
+                "composer-phar",
+                "composer-script",
+                "gpg-verification",
+                "phar",
+                "phar-handling",
+                "phar-management"
+            ],
+            "time": "2018-03-20T21:26:34+00:00"
         },
         {
             "name": "zendframework/zend-code",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-  level: 2
+  level: 3
   paths:
     - ./src
     - ./tests

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-  level: 0
+  level: 2
   paths:
     - ./src
     - ./tests

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-  level: 3
+  level: max
   paths:
     - ./src
     - ./tests

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,3 +5,4 @@ parameters:
     - ./tests
   excludes_analyse:
     - %currentWorkingDirectory%/tests/bitExpert/Disco/Config/NonExistentReturnTypeConfiguration.php
+    - %currentWorkingDirectory%/tests/bitExpert/Disco/Config/WrongReturnTypeConfiguration.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,7 @@
+parameters:
+  level: 0
+  paths:
+    - ./src
+    - ./tests
+  excludes_analyse:
+    - %currentWorkingDirectory%/tests/bitExpert/Disco/Config/NonExistentReturnTypeConfiguration.php

--- a/src/bitExpert/Disco/AnnotationBeanFactory.php
+++ b/src/bitExpert/Disco/AnnotationBeanFactory.php
@@ -30,8 +30,8 @@ class AnnotationBeanFactory implements BeanFactory
     /**
      * Creates a new {@link \bitExpert\Disco\BeanFactory}.
      *
-     * @param $configClassName string
-     * @param array $parameters
+     * @param string                   $configClassName
+     * @param array                    $parameters
      * @param BeanFactoryConfiguration $config
      */
     public function __construct($configClassName, array $parameters = [], BeanFactoryConfiguration $config = null)

--- a/src/bitExpert/Disco/Proxy/Configuration/ConfigurationFactory.php
+++ b/src/bitExpert/Disco/Proxy/Configuration/ConfigurationFactory.php
@@ -44,13 +44,13 @@ class ConfigurationFactory extends AbstractBaseFactory
      * @param BeanFactoryConfiguration $config
      * @param string $configClassName name of the configuration class
      * @param array $parameters
-     * @return object
+     * @return AliasContainerInterface
      */
     public function createInstance(
         BeanFactoryConfiguration $config,
         string $configClassName,
         array $parameters = []
-    ): object {
+    ): AliasContainerInterface {
         $proxyClassName = $this->generateProxy($configClassName);
         return new $proxyClassName($config, $parameters);
     }

--- a/src/bitExpert/Disco/Proxy/Configuration/ConfigurationGenerator.php
+++ b/src/bitExpert/Disco/Proxy/Configuration/ConfigurationGenerator.php
@@ -77,8 +77,8 @@ class ConfigurationGenerator implements ProxyGeneratorInterface
         $parameterValuesProperty = new ParameterValuesProperty();
         $beanFactoryConfigurationProperty = new BeanFactoryConfigurationProperty();
         $aliasesProperty = new AliasesProperty();
-        $getParameterMethod = new GetParameter($originalClass, $parameterValuesProperty);
-        $wrapBeanAsLazyMethod = new WrapBeanAsLazy($originalClass, $beanFactoryConfigurationProperty);
+        $getParameterMethod = new GetParameter($parameterValuesProperty);
+        $wrapBeanAsLazyMethod = new WrapBeanAsLazy($beanFactoryConfigurationProperty);
 
         try {
             $reader = new AnnotationReader();
@@ -198,7 +198,6 @@ class ConfigurationGenerator implements ProxyGeneratorInterface
 
         $classGenerator->addMethodFromGenerator(
             new Constructor(
-                $originalClass,
                 $parameterValuesProperty,
                 $sessionBeansProperty,
                 $beanFactoryConfigurationProperty,
@@ -215,16 +214,10 @@ class ConfigurationGenerator implements ProxyGeneratorInterface
             )
         );
         $classGenerator->addMethodFromGenerator(
-            new GetAlias(
-                $originalClass,
-                $aliasesProperty
-            )
+            new GetAlias($aliasesProperty)
         );
         $classGenerator->addMethodFromGenerator(
-            new HasAlias(
-                $originalClass,
-                $aliasesProperty
-            )
+            new HasAlias($aliasesProperty)
         );
     }
 }

--- a/src/bitExpert/Disco/Proxy/Configuration/MethodGenerator/Constructor.php
+++ b/src/bitExpert/Disco/Proxy/Configuration/MethodGenerator/Constructor.php
@@ -29,7 +29,6 @@ class Constructor extends MethodGenerator
     /**
      * Creates a new {@link \bitExpert\Disco\Proxy\Configuration\MethodGenerator\Constructor}.
      *
-     * @param ReflectionClass $originalClass
      * @param ParameterValuesProperty $parameterValuesProperty
      * @param SessionBeansProperty $sessionBeansProperty
      * @param BeanFactoryConfigurationProperty $beanFactoryConfigurationProperty
@@ -37,7 +36,6 @@ class Constructor extends MethodGenerator
      * @param string[] $beanPostProcessorMethodNames
      */
     public function __construct(
-        ReflectionClass $originalClass,
         ParameterValuesProperty $parameterValuesProperty,
         SessionBeansProperty $sessionBeansProperty,
         BeanFactoryConfigurationProperty $beanFactoryConfigurationProperty,

--- a/src/bitExpert/Disco/Proxy/Configuration/MethodGenerator/GetAlias.php
+++ b/src/bitExpert/Disco/Proxy/Configuration/MethodGenerator/GetAlias.php
@@ -27,11 +27,10 @@ class GetAlias extends MethodGenerator
     /**
      * Creates a new {@link \bitExpert\Disco\Proxy\Configuration\MethodGenerator\GetAlias}.
      *
-     * @param ReflectionClass $originalClass
      * @param AliasesProperty $aliasesProperty
      * @throws InvalidArgumentException
      */
-    public function __construct(ReflectionClass $originalClass, AliasesProperty $aliasesProperty)
+    public function __construct(AliasesProperty $aliasesProperty)
     {
         parent::__construct('getAlias');
 

--- a/src/bitExpert/Disco/Proxy/Configuration/MethodGenerator/GetParameter.php
+++ b/src/bitExpert/Disco/Proxy/Configuration/MethodGenerator/GetParameter.php
@@ -27,11 +27,10 @@ class GetParameter extends MethodGenerator
     /**
      * Creates a new {@link \bitExpert\Disco\Proxy\Configuration\MethodGenerator\GetParameter}.
      *
-     * @param ReflectionClass $originalClass
      * @param ParameterValuesProperty $parameterValueProperty
      * @throws InvalidArgumentException
      */
-    public function __construct(ReflectionClass $originalClass, ParameterValuesProperty $parameterValueProperty)
+    public function __construct(ParameterValuesProperty $parameterValueProperty)
     {
         parent::__construct(UniqueIdentifierGenerator::getIdentifier('getParameter'));
 

--- a/src/bitExpert/Disco/Proxy/Configuration/MethodGenerator/HasAlias.php
+++ b/src/bitExpert/Disco/Proxy/Configuration/MethodGenerator/HasAlias.php
@@ -26,11 +26,10 @@ class HasAlias extends MethodGenerator
     /**
      * Creates a new {@link \bitExpert\Disco\Proxy\Configuration\MethodGenerator\HasAlias}.
      *
-     * @param ReflectionClass $originalClass
      * @param AliasesProperty $aliasesProperty
      * @throws InvalidArgumentException
      */
-    public function __construct(ReflectionClass $originalClass, AliasesProperty $aliasesProperty)
+    public function __construct(AliasesProperty $aliasesProperty)
     {
         parent::__construct('hasAlias');
 

--- a/src/bitExpert/Disco/Proxy/Configuration/MethodGenerator/ParameterAwareMethodGenerator.php
+++ b/src/bitExpert/Disco/Proxy/Configuration/MethodGenerator/ParameterAwareMethodGenerator.php
@@ -34,7 +34,7 @@ class ParameterAwareMethodGenerator extends MethodGenerator
     ): string {
         $parameters = [];
         foreach ($methodParameters as $methodParameter) {
-            /** @var $methodParameter Parameter */
+            /** @var Parameter $methodParameter */
             $defaultValue = $methodParameter->getDefaultValue();
             switch (\gettype($defaultValue)) {
                 case 'string':

--- a/src/bitExpert/Disco/Proxy/Configuration/MethodGenerator/WrapBeanAsLazy.php
+++ b/src/bitExpert/Disco/Proxy/Configuration/MethodGenerator/WrapBeanAsLazy.php
@@ -26,11 +26,9 @@ class WrapBeanAsLazy extends MethodGenerator
     /**
      * Creates a new {@link \bitExpert\Disco\Proxy\LazyBean\MethodGenerator\Constructor}.
      *
-     * @param ReflectionClass $originalClass
      * @param BeanFactoryConfigurationProperty $beanFactoryConfigurationProperty
      */
     public function __construct(
-        ReflectionClass $originalClass,
         BeanFactoryConfigurationProperty $beanFactoryConfigurationProperty
     ) {
         parent::__construct(UniqueIdentifierGenerator::getIdentifier('wrapBeanAsLazy'));

--- a/tests/bitExpert/Disco/Proxy/Configuration/ConfigurationGeneratorUnitTest.php
+++ b/tests/bitExpert/Disco/Proxy/Configuration/ConfigurationGeneratorUnitTest.php
@@ -38,7 +38,7 @@ class ConfigurationGeneratorUnitTest extends TestCase
     private $configGenerator;
 
     /**
-     * @var ClassGenerator|PHPUnit_Framework_MockObject_MockObject
+     * @var ClassGenerator|\PHPUnit\Framework\MockObject\MockObject
      */
     private $classGenerator;
 

--- a/tests/bitExpert/Disco/Store/SerializableBeanStoreUnitTest.php
+++ b/tests/bitExpert/Disco/Store/SerializableBeanStoreUnitTest.php
@@ -82,8 +82,8 @@ class SerializableBeanStoreUnitTest extends TestCase
     {
         $this->beanStore->add('bean', $bean);
 
-        $this->beanStore = serialize($this->beanStore);
-        $this->beanStore = unserialize($this->beanStore);
+        $beanStore       = serialize($this->beanStore);
+        $this->beanStore = unserialize($beanStore);
 
         $beanFromStore = $this->beanStore->get('bean');
         self::assertEquals($bean, $beanFromStore);


### PR DESCRIPTION
This PR sets the PHPStan level to `max` though the issues that pop up (so far 23) are actually not issues with the codebase but with PHPStan as it interprets things wrongly or in a way that is documented differently.

That includes mainly problems with Mocked classes and their methods but also ignoring in-code `@var` -comments and trying to resolve class-signatures based on return-types declared in interfaces. 

This PR is based on #123 