### PR TITLE
Fix PHPStan issues

### DIFF
--- a/src/bitExpert/Disco/Annotations/AnnotationAttributeParser.php
+++ b/src/bitExpert/Disco/Annotations/AnnotationAttributeParser.php
@@ -15,9 +15,9 @@ namespace bitExpert\Disco\Annotations;
 final class AnnotationAttributeParser
 {
     /**
-     * Helper function to cast a string value to a boolean representation.
+     * Helper function to cast any value to a boolean representation.
      *
-     * @param string|bool $value
+     * @param mixed $value
      * @return bool
      */
     public static function parseBooleanValue($value): bool

--- a/src/bitExpert/Disco/Annotations/Bean.php
+++ b/src/bitExpert/Disco/Annotations/Bean.php
@@ -90,7 +90,7 @@ final class Bean extends ParameterAwareAnnotation
     /**
      * Helper methd to ensure that the passed aliases are of {@link \bitExpert\Disco\Annotations\Alias} type.
      *
-     * @param Alias[] $aliases
+     * @param Alias ...$aliases
      */
     private function setAliases(Alias ...$aliases): void
     {

--- a/src/bitExpert/Disco/Proxy/Configuration/ConfigurationGenerator.php
+++ b/src/bitExpert/Disco/Proxy/Configuration/ConfigurationGenerator.php
@@ -115,10 +115,10 @@ class ConfigurationGenerator implements ProxyGeneratorInterface
                 $method->name
             );
 
-            /* @var \bitExpert\Disco\Annotations\Bean $beanAnnotation */
+            /** @var \bitExpert\Disco\Annotations\Bean|null $beanAnnotation */
             $beanAnnotation = $reader->getMethodAnnotation($method, Bean::class);
             if (null === $beanAnnotation) {
-                /* @var \bitExpert\Disco\Annotations\Bean $beanAnnotation */
+                /** @var \bitExpert\Disco\Annotations\BeanPostProcessor $beanAnnotation */
                 $beanAnnotation = $reader->getMethodAnnotation($method, BeanPostProcessor::class);
                 if ($beanAnnotation instanceof BeanPostProcessor) {
                     $postProcessorMethods[] = $method->name;

--- a/src/bitExpert/Disco/Proxy/LazyBean/LazyBeanFactory.php
+++ b/src/bitExpert/Disco/Proxy/LazyBean/LazyBeanFactory.php
@@ -23,7 +23,7 @@ use ProxyManager\ProxyGenerator\ProxyGeneratorInterface;
 class LazyBeanFactory extends AbstractBaseFactory
 {
     /**
-     * @var LazyBeanGenerator
+     * @var LazyBeanGenerator|null
      */
     private $generator;
     /**


### PR DESCRIPTION
This PR fixes most of the issues PHPStan showed. 

Still existent are the issues with PHPUnit but they are not easily to solve as that would require the PHPUnit plugin for PHPStan but that requires PHPUnit 7. But the update to PHPUnit 7 does not work that easily due to composer dependency hell...

Moving to PHARs might solve that.